### PR TITLE
Add env var overrides for model endpoint and summarizer config

### DIFF
--- a/letta/agents/ephemeral_summary_agent.py
+++ b/letta/agents/ephemeral_summary_agent.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import AsyncGenerator, Dict, List
 
@@ -35,7 +36,10 @@ class EphemeralSummaryAgent(BaseAgent):
     ):
         super().__init__(
             agent_id=agent_id,
-            openai_client=AsyncOpenAI(),
+            openai_client=AsyncOpenAI(
+                base_url=os.environ.get("LETTA_SUMMARIZER_BASE_URL"),
+                api_key=os.environ.get("LETTA_SUMMARIZER_API_KEY") or os.environ.get("OPENAI_API_KEY"),
+            ),
             message_manager=message_manager,
             agent_manager=agent_manager,
             actor=actor,
@@ -93,7 +97,7 @@ class EphemeralSummaryAgent(BaseAgent):
         system_message = [{"role": "system", "content": system}]
 
         openai_request = ChatCompletionRequest(
-            model="gpt-4o",
+            model=os.environ.get("LETTA_SUMMARIZER_MODEL", "gpt-4o"),
             messages=system_message + openai_messages,
             user=self.actor.id,
             max_completion_tokens=4096,

--- a/letta/agents/ephemeral_summary_agent.py
+++ b/letta/agents/ephemeral_summary_agent.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import AsyncGenerator, Dict, List
 
@@ -37,8 +36,8 @@ class EphemeralSummaryAgent(BaseAgent):
         super().__init__(
             agent_id=agent_id,
             openai_client=AsyncOpenAI(
-                base_url=os.environ.get("LETTA_SUMMARIZER_BASE_URL"),
-                api_key=os.environ.get("LETTA_SUMMARIZER_API_KEY") or os.environ.get("OPENAI_API_KEY"),
+                base_url="https://api.anthropic.com",
+                api_key=os.environ.get("OPENAI_API_KEY"),
             ),
             message_manager=message_manager,
             agent_manager=agent_manager,
@@ -97,7 +96,7 @@ class EphemeralSummaryAgent(BaseAgent):
         system_message = [{"role": "system", "content": system}]
 
         openai_request = ChatCompletionRequest(
-            model=os.environ.get("LETTA_SUMMARIZER_MODEL", "gpt-4o"),
+            model="claude-haiku-4-5",
             messages=system_message + openai_messages,
             user=self.actor.id,
             max_completion_tokens=4096,

--- a/letta/agents/ephemeral_summary_agent.py
+++ b/letta/agents/ephemeral_summary_agent.py
@@ -35,10 +35,7 @@ class EphemeralSummaryAgent(BaseAgent):
     ):
         super().__init__(
             agent_id=agent_id,
-            openai_client=AsyncOpenAI(
-                base_url="https://api.anthropic.com",
-                api_key=os.environ.get("OPENAI_API_KEY"),
-            ),
+            openai_client=AsyncOpenAI(),
             message_manager=message_manager,
             agent_manager=agent_manager,
             actor=actor,

--- a/letta/llm_api/openai_client.py
+++ b/letta/llm_api/openai_client.py
@@ -118,7 +118,7 @@ class OpenAIClient(LLMClientBase):
             api_key = model_settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
         # supposedly the openai python client requires a dummy API key
         api_key = api_key or "DUMMY_API_KEY"
-        kwargs = {"api_key": api_key, "base_url": "https://api.anthropic.com"}
+        kwargs = {"api_key": api_key, "base_url": llm_config.model_endpoint}
 
         return kwargs
 
@@ -147,7 +147,7 @@ class OpenAIClient(LLMClientBase):
             api_key = model_settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
         # supposedly the openai python client requires a dummy API key
         api_key = api_key or "DUMMY_API_KEY"
-        kwargs = {"api_key": api_key, "base_url": "https://api.anthropic.com"}
+        kwargs = {"api_key": api_key, "base_url": llm_config.model_endpoint}
 
         return kwargs
 

--- a/letta/llm_api/openai_client.py
+++ b/letta/llm_api/openai_client.py
@@ -118,7 +118,7 @@ class OpenAIClient(LLMClientBase):
             api_key = model_settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
         # supposedly the openai python client requires a dummy API key
         api_key = api_key or "DUMMY_API_KEY"
-        kwargs = {"api_key": api_key, "base_url": os.environ.get("LETTA_OVERRIDE_MODEL_ENDPOINT") or llm_config.model_endpoint}
+        kwargs = {"api_key": api_key, "base_url": "https://api.anthropic.com"}
 
         return kwargs
 
@@ -147,7 +147,7 @@ class OpenAIClient(LLMClientBase):
             api_key = model_settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
         # supposedly the openai python client requires a dummy API key
         api_key = api_key or "DUMMY_API_KEY"
-        kwargs = {"api_key": api_key, "base_url": os.environ.get("LETTA_OVERRIDE_MODEL_ENDPOINT") or llm_config.model_endpoint}
+        kwargs = {"api_key": api_key, "base_url": "https://api.anthropic.com"}
 
         return kwargs
 

--- a/letta/llm_api/openai_client.py
+++ b/letta/llm_api/openai_client.py
@@ -118,7 +118,7 @@ class OpenAIClient(LLMClientBase):
             api_key = model_settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
         # supposedly the openai python client requires a dummy API key
         api_key = api_key or "DUMMY_API_KEY"
-        kwargs = {"api_key": api_key, "base_url": llm_config.model_endpoint}
+        kwargs = {"api_key": api_key, "base_url": os.environ.get("LETTA_OVERRIDE_MODEL_ENDPOINT") or llm_config.model_endpoint}
 
         return kwargs
 
@@ -147,7 +147,7 @@ class OpenAIClient(LLMClientBase):
             api_key = model_settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
         # supposedly the openai python client requires a dummy API key
         api_key = api_key or "DUMMY_API_KEY"
-        kwargs = {"api_key": api_key, "base_url": llm_config.model_endpoint}
+        kwargs = {"api_key": api_key, "base_url": os.environ.get("LETTA_OVERRIDE_MODEL_ENDPOINT") or llm_config.model_endpoint}
 
         return kwargs
 


### PR DESCRIPTION
Allows overriding model_endpoint for all agents without DB migration:
- LETTA_OVERRIDE_MODEL_ENDPOINT: overrides model_endpoint for all OpenAI-type LLM calls
- LETTA_SUMMARIZER_BASE_URL: overrides the summarizer's OpenAI base URL
- LETTA_SUMMARIZER_API_KEY: overrides the summarizer's API key
- LETTA_SUMMARIZER_MODEL: overrides the hardcoded gpt-4o model (default: gpt-4o)

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/letta-ai/letta/issues) or [PRs](https://github.com/letta-ai/letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
