### PR TITLE
fallback to synthetic send_message when model skips tool call

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -33,7 +33,7 @@ from letta.schemas.letta_response import LettaResponse
 from letta.schemas.letta_stop_reason import LettaStopReason, StopReasonType
 from letta.schemas.llm_config import LLMConfig
 from letta.schemas.message import Message, MessageCreate
-from letta.schemas.openai.chat_completion_response import ToolCall, UsageStatistics
+from letta.schemas.openai.chat_completion_response import FunctionCall, ToolCall, UsageStatistics
 from letta.schemas.provider_trace import ProviderTraceCreate
 from letta.schemas.tool_execution_result import ToolExecutionResult
 from letta.schemas.usage import LettaUsageStatistics
@@ -259,8 +259,19 @@ class LettaAgent(BaseAgent):
             )
 
             if not response.choices[0].message.tool_calls:
-                # TODO: make into a real error
-                raise ValueError("No tool calls found in response, model must make a tool call")
+                text = response.choices[0].message.content
+                if text:
+                    synthetic = ToolCall(
+                        id=f"synthetic_{uuid.uuid4().hex[:8]}",
+                        function=FunctionCall(
+                            name="send_message",
+                            arguments=json.dumps({"message": text}),
+                        ),
+                    )
+                    response.choices[0].message.tool_calls = [synthetic]
+                    logger.warning("Model returned text without a tool call; wrapping as synthetic send_message.")
+                else:
+                    raise ValueError("No tool calls found in response, model must make a tool call")
             tool_call = response.choices[0].message.tool_calls[0]
             if response.choices[0].message.reasoning_content:
                 reasoning = [
@@ -414,8 +425,19 @@ class LettaAgent(BaseAgent):
             )
 
             if not response.choices[0].message.tool_calls:
-                # TODO: make into a real error
-                raise ValueError("No tool calls found in response, model must make a tool call")
+                text = response.choices[0].message.content
+                if text:
+                    synthetic = ToolCall(
+                        id=f"synthetic_{uuid.uuid4().hex[:8]}",
+                        function=FunctionCall(
+                            name="send_message",
+                            arguments=json.dumps({"message": text}),
+                        ),
+                    )
+                    response.choices[0].message.tool_calls = [synthetic]
+                    logger.warning("Model returned text without a tool call; wrapping as synthetic send_message.")
+                else:
+                    raise ValueError("No tool calls found in response, model must make a tool call")
             tool_call = response.choices[0].message.tool_calls[0]
             if response.choices[0].message.reasoning_content:
                 reasoning = [


### PR DESCRIPTION
When the underlying LLM returns plain text without a tool_call, wrap the text as a synthetic send_message tool call instead of raising ValueError (which becomes HTTP 400 upstream). Empty responses still error as before.

Affects both step_stream_no_tokens and _step paths in LettaAgent.

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/letta-ai/letta/issues) or [PRs](https://github.com/letta-ai/letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
