### PR TITLE
debug: log message roles in sanity-cache block

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -413,7 +413,7 @@ class AnthropicClient(LLMClientBase):
         # Currently gated to userId=92744418 for safe rollout.
         if self.at_user_id == "92744418":
             logger.warning(
-                f"[sanity-cache] roles in data['messages']: {[m.get('role') for m in data['messages']][:10]}"
+                f"[sanity-cache] roles in data['messages']: {[m.get('role', 'unknown') for m in data['messages']][:10]}"
             )
             _sanity_texts = []
             _filtered_messages = []

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -412,6 +412,9 @@ class AnthropicClient(LLMClientBase):
         # Works for both Anthropic and Bedrock paths.
         # Currently gated to userId=92744418 for safe rollout.
         if self.at_user_id == "92744418":
+            logger.warning(
+                f"[sanity-cache] roles in data['messages']: {[m.get('role') for m in data['messages']][:10]}"
+            )
             _sanity_texts = []
             _filtered_messages = []
             for msg in data["messages"]:


### PR DESCRIPTION
## Summary
- Adds a `logger.warning` inside the `at_user_id == "92744418"` gate in `build_request_data()`
- Logs the first 10 roles from `data["messages"]` so we can see whether go-ai-chat's system messages arrive as `role:system` or get transformed by Letta's pipeline before reaching the LLM client
- Cache block size in test data was unchanged (~7,100 tokens before and after), suggesting the `role == "system"` check never matches — this log will confirm the root cause

## How to test
Deploy, send a message as userId 92744418, grep Letta server logs for `[sanity-cache]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)