### PR TITLE
fix: insert sanity cache block before dynamic_part_2, not after

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -432,10 +432,19 @@ class AnthropicClient(LLMClientBase):
                 else:
                     _filtered_messages.append(msg)
             if _sanity_texts:
+                # Insert AFTER the last cached block (static_part_2), BEFORE the trailing
+                # dynamic block (dynamic_part_2 = memory_metadata). Appending at the end
+                # places the cache checkpoint after dynamic content that changes every call,
+                # causing a ~45k token cache write every request at premium write cost with
+                # zero reads. Inserting before the dynamic tail keeps the cache key stable.
+                insert_pos = len(data["system"])  # fallback: append
+                for i, block in enumerate(data["system"]):
+                    if block.get("cache_control"):
+                        insert_pos = i + 1
                 logger.warning(
-                    f"[sanity-cache] moved {len(_sanity_texts)} SYSTEM ALERT messages to cached system block"
+                    f"[sanity-cache] moved {len(_sanity_texts)} SYSTEM ALERT messages to cached system block at pos {insert_pos}"
                 )
-                data["system"].append({
+                data["system"].insert(insert_pos, {
                     "type": "text",
                     "text": "\n\n".join(_sanity_texts),
                     "cache_control": {"type": "ephemeral"},


### PR DESCRIPTION
## Problem
The previous fix (PR #47) was appending the sanity block at the end of `data["system"]`, after `dynamic_part_2` (memory_metadata). Anthropic's cache checkpoint at that position covers all preceding content including the dynamic part, which changes every call — causing a ~45k token cache write every request at $3.75/MTok with zero reads. Net effect: more expensive than before.

## Fix
Insert the sanity block right after the last cached block (`static_part_2`, identified by scanning for the last `cache_control` entry), and before the trailing dynamic block. The cache key then only covers stable content and hits reliably after the first call.

## Expected token usage after deploy
- First call: `cache_creation_input_tokens` ~8,300 (sanity block written)
- Subsequent calls: `cache_creation_input_tokens` 0, `cache_read_input_tokens` ~8,300

🤖 Generated with [Claude Code](https://claude.com/claude-code)