### PR TITLE
Pin mistralai to git source (work around PyPI quarantine)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ matplotlib = "^3.10.1"
 asyncpg = {version = "^0.30.0", optional = true}
 tavily-python = "^0.7.2"
 async-lru = "^2.0.5"
-mistralai = "^1.8.1"
+mistralai = {git = "https://github.com/mistralai/client-python.git", tag = "v1.8.1"}
 uvloop = {version = "^0.21.0", optional = true}
 granian = {version = "^2.3.2", extras = ["uvloop", "reload"], optional = true}
 redis = {version = "^6.2.0", optional = true}


### PR DESCRIPTION
## Summary
Switches the `mistralai` dependency from PyPI to its upstream GitHub source at the v1.8.1 tag. Single-line change in `pyproject.toml`. No runtime behaviour change — identical Python source, identical version.

```diff
-mistralai = "^1.8.1"
+mistralai = {git = "https://github.com/mistralai/client-python.git", tag = "v1.8.1"}
```

## Why this is needed *now*

The `mistralai` package is currently quarantined on PyPI:
```
$ curl https://pypi.org/pypi/mistralai/json
{"message": "Not Found"}

$ curl https://pypi.org/simple/mistralai/
... <meta name="pypi:project-status" content="quarantined">
```

Any fresh `poetry lock` against PyPI fails with `Package mistralai (1.8.1) not found`. We saw this in:
- GitHub Actions: `Test Package Installation` workflow on the PR #50 merge → exit code 1 on `pip install '.[external-tools,postgres,dev,server,ollama]'`.
- Jenkins: build `letta-main-custom-d8885760-20260512-11-36-44` → step `#12 [builder 8/8] RUN poetry lock && poetry install --all-extras` failed with the same error.

## Why is current `main-custom` currently green if PyPI is broken?

It's not actually green — it's **Docker BuildKit cache replay**. The PR #51 revert restored the source tree to be byte-identical to the pre-PR-#50 state, which lets BuildKit reuse the install layer from before PyPI quarantined the package. See Jenkins build `letta-main-custom-e65eb28d-20260512-11-46-16`, step `#14 [builder 8/8] RUN poetry lock && poetry install --all-extras` — status **`CACHED`**. `poetry lock` never re-ran. PyPI was never contacted.

The first commit to `main-custom` whose source tree differs from the cached state invalidates that cache and breaks the build. This PR is intentionally one of those — it changes `pyproject.toml`, so the COPY layer hash changes and `poetry lock` actually runs against the new git source, proving the fix works (or doesn't, in which case we'll know immediately).

## What happens to `poetry.lock`?

Not regenerated in this commit. The Dockerfile already runs `poetry lock && poetry install --all-extras` on every build (`Dockerfile:40`), so the lock entry for `mistralai` will be rewritten against the git source automatically during the next Jenkins build. If you'd like the lockfile updated explicitly in this PR, say so and I'll run `poetry lock` locally and append the regenerated lockfile.

## Test plan

- [ ] Merge this PR
- [ ] Trigger Jenkins build on `main-custom`
- [ ] Confirm step `#14 [builder 8/8] RUN poetry lock && poetry install --all-extras` runs fresh (not CACHED) and succeeds — i.e. `poetry lock` successfully resolves `mistralai` from the git source
- [ ] Confirm image is pushed to ECR and Helm deploys successfully
- [ ] Run a smoke test against the deployed pods (e.g. send a chat message that exercises the `/v1/agents/{id}/messages` endpoint) to confirm runtime behaviour is unchanged

## Rollback

Single-line revert of `pyproject.toml`. No migrations, no state changes, no API contract changes.

## Follow-ups (not blocking this PR)

1. Long-term: replace `poetry lock` in the Dockerfile with `poetry install --no-update` (after committing a stable lockfile). The build should not re-resolve dependencies against live PyPI on every image build — that exposes us to upstream availability events like this one.
2. **Security:** the Jenkins pipeline currently `cat`s `values.yaml` to console after token replacement, which leaks prod secrets (Anthropic / OpenAI / Gemini / AWS / Azure / Postgres / Redis / server password) into every build log. Recommend rotating affected credentials and removing the `cat` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)