### PR TITLE
Cache optimization v2 (gated to test user 92744418)

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -42,9 +42,10 @@ from letta.settings import model_settings
 
 DUMMY_FIRST_USER_MESSAGE = "User initializing bootup sequence."
 
-# Gate for cache-observability logs. Set to a user_id to capture per-request
-# structure + Anthropic usage breakdown for that user only. Empty string disables.
-CACHE_OBS_USER_ID = "117607352"
+# Gate for cache-observability logs + v2 cache-optimization path. Set to a
+# single user_id to capture per-request structure + Anthropic usage breakdown
+# AND apply the v2 cache layout for that user only. Empty string disables both.
+CACHE_OBS_USER_ID = "92744418"
 
 logger = get_logger(__name__)
 

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -411,8 +411,24 @@ class AnthropicClient(LLMClientBase):
         if messages[0].role != "system":
             raise RuntimeError(f"First message is not a system message, instead has role {messages[0].role}")
         system_content = messages[0].content if isinstance(messages[0].content, str) else messages[0].content[0].text
-        static_part_1, dynamic_part_1, static_part_2, dynamic_part_2 = self._split_system_message_for_caching(system_content)
-        data["system"] = self._add_cache_control_to_system_message(static_part_1, dynamic_part_1, static_part_2, dynamic_part_2)
+
+        # Gated cache-optimization path: for at_user_id == CACHE_OBS_USER_ID, use the v2 splitter
+        # that keeps base instructions and tool_usage_rules cached even when the persona block
+        # mutates between turns. Also stabilizes <memory_metadata> so it stops invalidating
+        # downstream cache lookups. All other users get the existing v1 path unchanged.
+        at_user_id_for_opt = getattr(self, "at_user_id", None)
+        use_v2_caching = bool(CACHE_OBS_USER_ID and at_user_id_for_opt == CACHE_OBS_USER_ID)
+        v2_split = self._split_system_message_v2_for_caching(system_content) if use_v2_caching else None
+        if v2_split is not None:
+            static_base, dynamic_persona, dynamic_user_memory, static_rules, dynamic_metadata = v2_split
+            if dynamic_metadata:
+                dynamic_metadata = self._stabilize_memory_metadata(dynamic_metadata)
+            data["system"] = self._add_cache_control_to_system_message_v2(
+                static_base, dynamic_persona, dynamic_user_memory, static_rules, dynamic_metadata
+            )
+        else:
+            static_part_1, dynamic_part_1, static_part_2, dynamic_part_2 = self._split_system_message_for_caching(system_content)
+            data["system"] = self._add_cache_control_to_system_message(static_part_1, dynamic_part_1, static_part_2, dynamic_part_2)
         data["messages"] = [
             m.to_anthropic_dict(
                 inner_thoughts_xml_tag=inner_thoughts_xml_tag,
@@ -428,6 +444,15 @@ class AnthropicClient(LLMClientBase):
 
         # Handle alternating messages
         data["messages"] = merge_tool_results_into_user_messages(data["messages"])
+
+        # Gated: cache the conversation tail by attaching cache_control: ephemeral to the
+        # last assistant message in the persisted history. With a stabilized system prefix
+        # (v2 splitter + stabilized memory_metadata), the next call's prefix will match up
+        # through this breakpoint and read everything from cache. Applied BEFORE prefix_fill
+        # so the prefix-fill assistant marker (appended below) stays uncached and never sits
+        # at the breakpoint position.
+        if use_v2_caching:
+            self._add_cache_control_to_last_assistant_message(data["messages"])
 
         # Prefix fill
         # https://docs.anthropic.com/en/api/messages#body-messages
@@ -517,6 +542,103 @@ class AnthropicClient(LLMClientBase):
             })
 
         return system_parts
+
+    def _split_system_message_v2_for_caching(self, system_content: str):
+        # v2 splitter: 5-part layout that keeps base instructions and tool_usage_rules cached
+        # even when the persona block is mutated by core_memory_append/replace.
+        #
+        # Layout vs v1:
+        #   v1: [base+persona] cached | [human+summary] | [tool_usage+files] cached | [memory_metadata]
+        #   v2: [base] cached | [persona] | [human+summary] | [tool_usage+files] cached | [memory_metadata]
+        #
+        # The trade-off: persona reads become uncached, but the base instructions (a larger,
+        # truly stable chunk) stop being invalidated on every persona append. Net win because
+        # cross-turn cache hit rate goes from near-zero to ~100% on the base prefix.
+        #
+        # Returns None when the markers needed for the 5-part split aren't present, so the
+        # caller can fall back to v1.
+        persona_start = system_content.find("<persona>")
+        persona_end = system_content.find("</persona>")
+        memory_blocks_end = system_content.find("</memory_blocks>")
+        memory_metadata_start = system_content.find("<memory_metadata>")
+
+        if persona_start == -1 or persona_end == -1 or memory_blocks_end == -1:
+            return None
+        if persona_start >= persona_end:
+            return None
+
+        persona_end += len("</persona>")
+        memory_blocks_end += len("</memory_blocks>")
+
+        static_base = system_content[:persona_start].strip()
+        dynamic_persona = system_content[persona_start:persona_end].strip()
+        dynamic_user_memory = system_content[persona_end:memory_blocks_end].strip()
+
+        if memory_metadata_start != -1 and memory_metadata_start > memory_blocks_end:
+            static_rules = system_content[memory_blocks_end:memory_metadata_start].strip()
+            dynamic_metadata = system_content[memory_metadata_start:].strip()
+        else:
+            static_rules = system_content[memory_blocks_end:].strip()
+            dynamic_metadata = ""
+
+        return static_base, dynamic_persona, dynamic_user_memory, static_rules, dynamic_metadata
+
+    def _add_cache_control_to_system_message_v2(self, static_base, dynamic_persona, dynamic_user_memory, static_rules, dynamic_metadata):
+        # Build the 5-part system block list with cache_control: ephemeral on static_base and
+        # static_rules only. Uses 2 of Anthropic's 4 available cache breakpoints, leaving room
+        # for a third on the messages array.
+        parts = []
+        if static_base:
+            parts.append({"type": "text", "text": static_base, "cache_control": {"type": "ephemeral"}})
+        if dynamic_persona:
+            parts.append({"type": "text", "text": dynamic_persona})
+        if dynamic_user_memory:
+            parts.append({"type": "text", "text": dynamic_user_memory})
+        if static_rules:
+            parts.append({"type": "text", "text": static_rules, "cache_control": {"type": "ephemeral"}})
+        if dynamic_metadata:
+            parts.append({"type": "text", "text": dynamic_metadata})
+        return parts
+
+    def _stabilize_memory_metadata(self, metadata_content: str) -> str:
+        # Replace per-second timestamp + recall/archival counts with hourly-stable text so
+        # this trailing block stops invalidating cache lookups on every turn. The agent still
+        # gets a coarse time reference and a reminder that recall tools exist; it never acts
+        # on exact recall/archival counts.
+        import datetime as _dt
+        now = _dt.datetime.now(_dt.timezone.utc)
+        hour_stamp = now.strftime("%Y-%m-%d %H UTC")
+        return (
+            "<memory_metadata>\n"
+            f"- Current hour: {hour_stamp}\n"
+            "- Recall and archival memory tools are available "
+            "(conversation_search, archival_memory_search).\n"
+            "</memory_metadata>"
+        )
+
+    def _add_cache_control_to_last_assistant_message(self, messages_list) -> None:
+        # Walk the messages array backwards, find the last assistant message in the persisted
+        # history, and attach cache_control: ephemeral to its last content block. This caches
+        # the entire conversation tail through that point. Next call has the same prefix +
+        # a new user turn, so it reads everything up to and including this message from cache.
+        if not messages_list:
+            return
+        last_assistant_idx = None
+        for i in range(len(messages_list) - 1, -1, -1):
+            msg = messages_list[i]
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                last_assistant_idx = i
+                break
+        if last_assistant_idx is None:
+            return
+        msg = messages_list[last_assistant_idx]
+        content = msg.get("content")
+        if isinstance(content, str):
+            msg["content"] = [{"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}]
+        elif isinstance(content, list) and content:
+            last_block = content[-1]
+            if isinstance(last_block, dict):
+                last_block["cache_control"] = {"type": "ephemeral"}
 
     def _log_cache_observation_request(self, data: dict, num_input_messages: int) -> None:
         # Emits a structured log line describing the request prefix structure


### PR DESCRIPTION
## Summary
Bundles four prompt-cache improvements gated to `at_user_id == "92744418"`. Non-gated users see the existing v1 cache layout unchanged. Targets the leaks identified in the `[CACHE_OBS_REQ]` / `[CACHE_OBS_USAGE]` logs from PR #54.

## Diagnosis from PR #54 logs

| Symptom | Evidence | Cost |
|---|---|---|
| Persona invalidates the `static_part_1` cache every turn | block-0 hash differs across all 12 turns; chars grow 14449→16787 monotonically | Cache writes on ~57% of calls (5.5k tokens × 1.25× premium), almost never read |
| `<tool_usage_rules>` is stable but uncached | block-1 hash `e339e205` constant across all 12 turns, in `dynamic_part_1` | 384 tokens × every call at 1× |
| Messages array is fully uncached every call | block-of-messages 6k–26k tokens, no `cache_control` anywhere on the messages array | The biggest single bucket of full-price input |
| `<memory_metadata>` mutates every turn | block-3 hash differs across all 12 turns (timestamp + recall count) | Prevents any messages-level cache breakpoint from ever hitting |

## What this PR changes (all gated on test user 92744418)

### 1. `_split_system_message_v2_for_caching` — 5-part layout
```
v1: [base+persona] cached | [human+summary] | [tool_usage+files] cached | [memory_metadata]
v2: [base] cached | [persona] | [human+summary] | [tool_usage+files] cached | [memory_metadata]
```
- `static_base` (base instructions only) → **cached**, stable across the entire session
- `dynamic_persona` (`<persona>` block) → uncached (it mutates anyway; stop letting it kill the cache)
- `dynamic_user_memory` (`<human>` + `<conversation_summary>`) → uncached
- `static_rules` (`<tool_usage_rules>` + `<files>`) → **cached**, stable
- `dynamic_metadata` (`<memory_metadata>`) → handled by change #2

Falls back to v1 if `<persona>` markers aren't present in the system content.

### 2. `_stabilize_memory_metadata` — hourly-stable tail
Replaces the per-call content (precise timestamp + recall/archival counts) with:
```xml
<memory_metadata>
- Current hour: 2026-05-13 12 UTC
- Recall and archival memory tools are available (conversation_search, archival_memory_search).
</memory_metadata>
```
Agent still gets a coarse time reference and knows its recall tools exist. It doesn't act on exact recall/archival counts. This is the only behavior-affecting change in the PR — see "behavior risk" below.

### 3. `_add_cache_control_to_last_assistant_message`
Walks `data["messages"]` backwards, finds the last assistant message in the persisted history, attaches `cache_control: ephemeral` to its last content block. With #1 and #2 stabilizing the prefix, the next call reads the full conversation tail from cache. Applied BEFORE prefix_fill, so the prefix-fill assistant marker is never the breakpoint.

### 4. Wiring in `build_request_data`
```python
at_user_id_for_opt = getattr(self, "at_user_id", None)
use_v2_caching = bool(CACHE_OBS_USER_ID and at_user_id_for_opt == CACHE_OBS_USER_ID)
v2_split = self._split_system_message_v2_for_caching(system_content) if use_v2_caching else None
if v2_split is not None:
    ...  # new v2 path with stabilized metadata
else:
    ...  # existing v1 path, byte-identical to today
```

Existing `[CACHE_OBS_REQ]` / `[CACHE_OBS_USAGE]` logs continue firing on the gated user — we'll see the v2 cache pattern directly comparable to the v1 baseline from PR #54.

## Cache breakpoint budget
Anthropic supports 4 cache breakpoints per request. After this PR (gated path):
- `static_base` (system) → breakpoint 1
- `static_rules` (system) → breakpoint 2
- Last assistant message → breakpoint 3
- 1 spare

## Expected impact on test user
Compared to the v1 baseline captured in PR #54 logs:
- Cross-turn `cache_read_input_tokens` should be ~consistently positive on every call (not just intra-turn 2nd steps)
- Total `input_tokens` (full-price) should drop sharply on multi-step calls
- `cache_creation_input_tokens` should fire only when persona/rules genuinely change in content, not every turn
- Estimated ~50–65% reduction in input cost on multi-step calls

If the numbers land near that, graduating to broader traffic is a one-line gate change.

## Behavior risk
**Only change #2 (memory_metadata stabilization) can affect agent reasoning.** Replacing the precise timestamp + recall/archival counts with hourly-precision text means:
- The agent's sense of "now" lags up to 59 minutes
- The agent no longer sees exact recall/archival sizes

Neither is referenced in the agent's system instructions as a load-bearing signal. But the test user gives us a real conversation to validate against before broadening.

If we observe behavior degradation, the safest fallback is to drop change #2 (keep memory_metadata as-is) and accept that change #3 won't actually cache-hit. That would still leave change #1's persona-cache fix in place, which alone should deliver ~30% input savings.

## Test plan
- [ ] Merge and deploy
- [ ] Send a 10–20 turn conversation as user `92744418`
- [ ] Grep `[CACHE_OBS_REQ]` and `[CACHE_OBS_USAGE]` and compare to PR #54 baseline
- [ ] Confirm: system_blocks now has 5 entries (was 4); block-0 hash is stable across turns; block-3 (`<memory_metadata>`) hash is stable within an hour; last assistant message in `data["messages"]` has `cache_control` set
- [ ] Confirm in usage: `cache_read_input_tokens` is positive on every call (not just intra-turn 2nd steps); `cache_creation_input_tokens` drops to near-zero for stable turns
- [ ] Spot-check the test user's conversation quality (does the agent still pull recall memory appropriately? does it reference time correctly?)
- [ ] If healthy, follow-up PR removes the `at_user_id` gate to graduate to all traffic

## Rollback
Single-file revert. Non-gated users were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)