### PR TITLE
Graduate cache v2 to 50% rollout (user_id mod 10)

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -42,10 +42,38 @@ from letta.settings import model_settings
 
 DUMMY_FIRST_USER_MESSAGE = "User initializing bootup sequence."
 
-# Gate for cache-observability logs + v2 cache-optimization path. Set to a
-# single user_id to capture per-request structure + Anthropic usage breakdown
-# AND apply the v2 cache layout for that user only. Empty string disables both.
+# Gate for cache-observability logs. Set to a single user_id to capture
+# per-request structure + Anthropic usage breakdown for that user only. Empty
+# string disables. The v2 cache-optimization path is now controlled by the
+# V2_CACHE_ROLLOUT_* knobs below, not by this constant.
 CACHE_OBS_USER_ID = "92744418"
+
+# v2 cache-layout rollout: deterministic 50/50 split by at_user_id % MOD.
+# Users whose (int(at_user_id) % V2_CACHE_ROLLOUT_MOD) < V2_CACHE_ROLLOUT_BUCKET_MAX
+# get the v2 system-block layout + memory_metadata stabilization + messages-tail
+# cache_control. The other half stays on the v1 path.
+# Test user CACHE_OBS_USER_ID is always force-included so observability logs
+# remain comparable to the PR #54 baseline.
+V2_CACHE_ROLLOUT_MOD = 10
+V2_CACHE_ROLLOUT_BUCKET_MAX = 5
+
+
+def _is_user_in_v2_cache_bucket(at_user_id):
+    # Returns True if the user_id falls in the v2 rollout bucket. False for
+    # missing/non-numeric ids so unknown traffic defaults to the v1 path (fail-closed).
+    if not at_user_id:
+        return False
+    if CACHE_OBS_USER_ID and at_user_id == CACHE_OBS_USER_ID:
+        return True
+    if V2_CACHE_ROLLOUT_BUCKET_MAX <= 0:
+        return False
+    if V2_CACHE_ROLLOUT_BUCKET_MAX >= V2_CACHE_ROLLOUT_MOD:
+        return True
+    try:
+        return (int(at_user_id) % V2_CACHE_ROLLOUT_MOD) < V2_CACHE_ROLLOUT_BUCKET_MAX
+    except (ValueError, TypeError):
+        return False
+
 
 logger = get_logger(__name__)
 
@@ -413,12 +441,14 @@ class AnthropicClient(LLMClientBase):
             raise RuntimeError(f"First message is not a system message, instead has role {messages[0].role}")
         system_content = messages[0].content if isinstance(messages[0].content, str) else messages[0].content[0].text
 
-        # Gated cache-optimization path: for at_user_id == CACHE_OBS_USER_ID, use the v2 splitter
-        # that keeps base instructions and tool_usage_rules cached even when the persona block
-        # mutates between turns. Also stabilizes <memory_metadata> so it stops invalidating
-        # downstream cache lookups. All other users get the existing v1 path unchanged.
+        # Cache-optimization rollout: 50/50 split by user_id % 10. Users in the v2
+        # bucket get the v2 splitter (keeps base instructions and tool_usage_rules
+        # cached even when persona mutates), stabilized <memory_metadata>, and
+        # cache_control on the last assistant message. The other 50% stay on v1.
+        # Test user CACHE_OBS_USER_ID is always in the v2 bucket so observability
+        # logs remain comparable to the PR #54 baseline.
         at_user_id_for_opt = getattr(self, "at_user_id", None)
-        use_v2_caching = bool(CACHE_OBS_USER_ID and at_user_id_for_opt == CACHE_OBS_USER_ID)
+        use_v2_caching = _is_user_in_v2_cache_bucket(at_user_id_for_opt)
         v2_split = self._split_system_message_v2_for_caching(system_content) if use_v2_caching else None
         if v2_split is not None:
             static_base, dynamic_persona, dynamic_user_memory, static_rules, dynamic_metadata = v2_split


### PR DESCRIPTION
## Summary
Graduates the v2 cache layout from PR #55 (gated to one test user) to a 50/50 traffic split based on `int(at_user_id) % 10`. Users in the v2 bucket get the new system-block layout, stabilized `<memory_metadata>`, and `cache_control` on the last assistant message. The other half stays on the existing v1 path.

```python
V2_CACHE_ROLLOUT_MOD = 10
V2_CACHE_ROLLOUT_BUCKET_MAX = 5  # users with (id % 10) < 5 get v2
```

## Validation from PR #55 single-user test (26-min session)

| Check | Result |
|---|---|
| `block-0` hash stable across all 18 REQ logs | ✅ `d9d8cabd` constant |
| `block-1` (persona) hash stable from turn 2 onwards | ✅ `73bd70f4` |
| Hour-boundary crossing (09 UTC → 10 UTC) | ✅ Clean transition |
| Cache reads on most calls | ✅ 13/17 hits (76%) |
| Cache creation drops to small refresh writes after first build | ✅ 170–500 tokens on hit calls (was 5500 in v1) |
| Bedrock + tool_use `cache_control` compatibility | ✅ All 17 calls were Bedrock, zero errors |
| Agent behavior (Hindi/Hinglish astrology consultant) | ✅ Coherent responses, correct tool use, retains date/timing references despite hourly-precision metadata |
| Input-cost reduction | ✅ ~44% in the test session |

The 4 cache misses in the test all correlate with either (a) Anthropic's 5-min TTL expiring during quiet gaps, or (b) Letta's tool-array hash flipping between requests — both orthogonal to our changes and expected/known issues.

## Rollout logic

```python
def _is_user_in_v2_cache_bucket(at_user_id):
    if not at_user_id:
        return False  # fail-closed for missing ids
    if CACHE_OBS_USER_ID and at_user_id == CACHE_OBS_USER_ID:
        return True  # always include test user
    if V2_CACHE_ROLLOUT_BUCKET_MAX <= 0:
        return False  # kill switch
    if V2_CACHE_ROLLOUT_BUCKET_MAX >= V2_CACHE_ROLLOUT_MOD:
        return True  # full graduation
    try:
        return (int(at_user_id) % V2_CACHE_ROLLOUT_MOD) < V2_CACHE_ROLLOUT_BUCKET_MAX
    except (ValueError, TypeError):
        return False  # non-numeric ids -> v1
```

**Deterministic** per user — same user always gets the same path within a deploy. Bucketing on `at_user_id` (the consultant-chat userId Letta receives from go-ai-chat via the `x_gb_user_id` header).

Verified with 11 edge-case smoke checks (None, empty, non-numeric, boundary values 4/5, test-user override) — all pass.

## What the test user keeps

- ✅ Test user `92744418` is force-included in the v2 bucket regardless of mod (since 92744418 % 10 == 8 would otherwise route them to v1). Keeps observability comparable to PR #54 baseline.
- ✅ `[CACHE_OBS_REQ]` and `[CACHE_OBS_USAGE]` logs remain gated to `CACHE_OBS_USER_ID` only. Log volume stays bounded to one user even as v2 traffic grows.

## Expected aggregate impact

Based on the single-user test's 44% input-cost reduction on a real conversation:

- **Pre-rollout daily input cost**: ~$40k/day total (mix of v1 on all users)
- **Post-rollout estimate**: 50% of traffic at ~44% savings = ~22% aggregate input-cost reduction = **~$9k/day saved**

If the aggregate metric lands near that, we ramp BUCKET_MAX to 10 (full graduation). If it lands meaningfully short or behavior regresses, drop BUCKET_MAX to 0 — instant rollback to v1 for everyone.

## What to watch in the first hour after deploy

1. **Aggregate `cache_read_input_tokens` in your existing cost dashboards.** Should roughly double from the PR #55 single-user baseline once 50% of traffic hits v2.
2. **5xx error rate.** Bedrock cache_control on tool_use blocks worked for the test user — should hold across all v2 traffic, but watch for spikes.
3. **Agent quality signals.** If your CSAT / retention / response-rating metrics drop on the v2 bucket vs v1, the metadata stabilization is biting. The two buckets are perfectly comparable cohorts (random 50/50 split on user_id), so A/B is clean.
4. **[CACHE_OBS_USAGE] logs from user 92744418.** Should continue to show the same ~76% hit rate as the PR #55 baseline.

## Rollback

One-line change: set `V2_CACHE_ROLLOUT_BUCKET_MAX = 0`. Everyone returns to v1 immediately. Or revert the single commit; same effect.

## Files changed
- `letta/llm_api/anthropic_client.py` — +38 / -8

## Follow-ups (not blocking)
1. File a Letta-side ticket on the tools-array hash non-determinism (causes ~10–15% of cache misses we'd otherwise avoid).
2. After 24–48h on 50% if numbers look good, follow-up PR sets `BUCKET_MAX = 10` to graduate fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)