### PR TITLE
Sort tools by name to fix cache invalidation (gated to test user 92744418)

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -429,6 +429,24 @@ class AnthropicClient(LLMClientBase):
             )
             tools_for_request = [OpenAITool(function=f) for f in tools_with_inner_thoughts]
 
+        # Test-user-gated: sort tools by name before serialization to eliminate the
+        # non-deterministic ordering from the SQLAlchemy `tools` relationship in
+        # letta/orm/agent.py (no `order_by` clause). When tools come back in different
+        # orders across calls, the entire request prefix hash changes and ALL cache
+        # breakpoints downstream invalidate, even though tool content is identical.
+        # Test logs from PR #55 show 3 distinct tools-hashes across one 26-min
+        # conversation (~22% of calls had a reordered tools list). Gated to
+        # CACHE_OBS_USER_ID so we can verify the effect in observability logs
+        # before graduating to all traffic.
+        _tools_sort_user_id = getattr(self, "at_user_id", None)
+        if (
+            tools_for_request
+            and len(tools_for_request) > 0
+            and CACHE_OBS_USER_ID
+            and _tools_sort_user_id == CACHE_OBS_USER_ID
+        ):
+            tools_for_request = sorted(tools_for_request, key=lambda t: t.function.name)
+
         if tools_for_request and len(tools_for_request) > 0:
             # TODO eventually enable parallel tool use
             data["tools"] = convert_tools_to_anthropic_format(tools_for_request)


### PR DESCRIPTION
## Summary
Single-purpose, low-risk fix targeting the largest identified cause of cache misses: non-deterministic tool list ordering from the SQLAlchemy relationship. Gated to test user `92744418` first so we can verify in observability logs before graduating.

## The bug

`letta/orm/agent.py:92` defines:

```python
tools: Mapped[List["Tool"]] = relationship(
    "Tool", secondary="tools_agents", lazy="selectin", passive_deletes=True
)
```

No `order_by`. PostgreSQL returns rows in internal page/index order, which is **not stable across queries** — different worker pods, different connections, even different queries within one pod can return tools in different orders.

Anthropic's prompt caching matches the cache prefix **by exact content**. Tools precede system blocks and messages in the request order. So when tools reorder, the entire request prefix hash changes and **every downstream cache breakpoint invalidates** — even though tool content is byte-identical.

## Evidence from PR #55 test logs

In a single 26-min conversation with 18 requests for one user, the `tools` field hash took on **3 distinct values**:

| Hash | When |
|---|---|
| `86f81c58` | Most common (~78%) |
| `9aee8f7c` | Occasional |
| `7cca969d` | Rare |

`tools.count` was always 6 and `tools.approx_tokens` was always 956 across all calls. Only ordering differed. **Approximately 22% of calls had a reordered tools list**, forcing a cache miss for everything downstream.

## The fix

In `letta/llm_api/anthropic_client.py`, just before `convert_tools_to_anthropic_format`:

```python
if tools_for_request and ... and at_user_id == CACHE_OBS_USER_ID:
    tools_for_request = sorted(tools_for_request, key=lambda t: t.function.name)
```

Alphabetical sort, stable across processes (Python's `sorted` with explicit key).

## Risk

**Low.** Tool ordering does NOT affect Anthropic's tool-selection behavior — tools are referenced by name in the API, and modern Claude models are not position-sensitive on tool selection. The sort is purely a cache optimization with no semantic side effects.

## Gating

Applied only when `at_user_id == CACHE_OBS_USER_ID` (currently `92744418`). All other users continue with whatever tool order they were getting before.

## Test plan
- [ ] Merge and deploy
- [ ] Send 10-20 turn conversation as user `92744418` (or wait for organic traffic if they're a real user)
- [ ] Grep `[CACHE_OBS_REQ]` for that user
- [ ] **Verify:** `tools.hash` is now constant across all calls (was flipping between 3 values)
- [ ] Grep `[CACHE_OBS_USAGE]` for that user
- [ ] **Verify:** `cache_read_input_tokens` climbs (no more reorder-induced misses)
- [ ] **Verify:** `cache_creation_input_tokens` drops (no more rewriting the prefix)
- [ ] Spot-check: agent's conversation quality is unchanged (no behavior regression from tool reordering)

## After verification
If the test user's hit rate climbs to 95%+ (was 76% in PR #55), follow-up PR drops the gate so it applies universally — both v1 and v2 paths benefit.

## Why ship to test user first (not directly to all)

The fix is mechanically simple. But the *magnitude* of impact — how much of the 44% miss rate is from this vs. other invalidation sources — is theoretical. Test user has observability logs that show us per-call detail the dashboard doesn't. We get a measured signal before committing to a graduation PR.

## Files changed
- `letta/llm_api/anthropic_client.py` (+18 / -0)

## Rollback
Single-file revert. Non-gated users were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)