### PR TITLE
Cache summarizer system prompt to reduce Haiku API spend

### DIFF
--- a/letta/agents/ephemeral_summary_agent.py
+++ b/letta/agents/ephemeral_summary_agent.py
@@ -130,11 +130,26 @@ class EphemeralSummaryAgent(BaseAgent):
 
             def _invoke():
                 client = anthropic.Anthropic(api_key=model_settings.anthropic_api_key)
-                return client.messages.create(
+                # Cache the ~11k-token summarizer system prompt. SUMMARIZER_FIRED logs
+                # show this code path runs roughly 1.5 times/second in production, each
+                # call previously paying full price for the entire system prompt. With
+                # cache_control: ephemeral and the prompt-caching-2024-07-31 beta, the
+                # same prompt becomes a cache_read at 0.1x cost on subsequent calls
+                # (within the 5-minute TTL). System prompt is fully static (loaded
+                # from prompts/summary_system_prompt.txt) so it caches across all
+                # summarizer invocations regardless of which agent triggered them.
+                return client.beta.messages.create(
                     model="claude-haiku-4-5",
                     max_tokens=1500,
-                    system=system,
+                    system=[
+                        {
+                            "type": "text",
+                            "text": system,
+                            "cache_control": {"type": "ephemeral"},
+                        }
+                    ],
                     messages=messages,
+                    betas=["prompt-caching-2024-07-31"],
                 )
 
             response = await asyncio.to_thread(_invoke)


### PR DESCRIPTION
## Summary
Wraps the EphemeralSummaryAgent's Anthropic call in the prompt-caching beta, adding ephemeral \`cache_control\` on its 11k-token system prompt. Zero behaviour change — same model, same prompt content, same output.

## Why this matters

The observability rollout in PR #59 added \`[SUMMARIZER_FIRED]\` event markers. Production data over a 32-second window showed ~50 summarizer invocations, projecting to **~130,000 fires/day**, all on Haiku 4.5 at $1/M input.

Pre-fix, every fire pays full price for the entire static system prompt. After PR #59 made this visible:

\`\`\`
130k fires/day × 11k tokens × $1/M = ~$1,400/day on summarizer system tokens alone
\`\`\`

## The fix

Change in \`letta/agents/ephemeral_summary_agent.py\` (the Anthropic branch — Azure path is untouched):

\`\`\`python
def _invoke():
    client = anthropic.Anthropic(api_key=model_settings.anthropic_api_key)
    return client.beta.messages.create(
        model="claude-haiku-4-5",
        max_tokens=1500,
        system=[
            {
                "type": "text",
                "text": system,
                "cache_control": {"type": "ephemeral"},
            }
        ],
        messages=messages,
        betas=["prompt-caching-2024-07-31"],
    )
\`\`\`

The system prompt is loaded from \`prompts/summary_system_prompt.txt\` — fully static, identical across every invocation regardless of which agent triggered it. With a 1.5-fire/sec rate, the 5-minute TTL keeps the cache warm continuously across all summarizer calls fleet-wide (Anthropic cache is API-key scoped + content-addressed).

## Expected savings

Haiku 4.5 pricing: input $1/M, cache_read $0.10/M, cache_write $1.25/M.

\`\`\`
Before: 130k × 11k × $1/M       = ~$1,430/day
After:  cache_read after first write
        ~1 write × 11k × $1.25/M / 5min × 12 (per hour) × 24 = ~$80/day cache writes
        130k × 11k × $0.10/M    = ~$143/day cache reads
        Total                    = ~$220/day
Savings:                          ~$1,200/day
\`\`\`

(Conservative — assumes cache writes happen every 5 min from cold. In practice with continuous traffic the cache stays warm and writes are rarer.)

## Behaviour risk

**Zero.** Prompt caching is semantically identical to non-cached calls per Anthropic's documentation: same model, same context, same output. The only difference is which Anthropic backend serves the prompt prefix.

## Test plan
- [ ] Merge and deploy
- [ ] Verify SUMMARIZER_FIRED rate is unchanged (we're not modifying when it fires)
- [ ] Anthropic dashboard: \`Cache write (5m)\` on the Haiku slice should jump from ~0 to non-trivial
- [ ] Anthropic dashboard: \`Cache read\` on the Haiku slice should grow correspondingly
- [ ] Total Haiku input-token cost should drop by ~80%
- [ ] Sanity-check a few summaries — content quality should be identical (the model sees the same prompt)

## Rollback
Single-commit revert. No state, no API contract changes.

## Files changed
- \`letta/agents/ephemeral_summary_agent.py\` (+17 / -2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)