### PR TITLE
Skip trivial MEMORY_REBUILDs (test-user gated)

### DIFF
--- a/letta/agents/base_agent.py
+++ b/letta/agents/base_agent.py
@@ -152,6 +152,50 @@ class BaseAgent(ABC):
                     except Exception:
                         pass
 
+                # Test-user-gated optimization: skip the system message rewrite when
+                # the ONLY differences are 'volatile attribute' values that update on
+                # nearly every call but represent no semantic memory change:
+                #   - chars_current="N" on memory block headers (bumps on every
+                #     core_memory_append, even by 1 char)
+                #   - the memory_edit_timestamp line (refreshed every rebuild)
+                # PR #59 observability data showed ~half of MEMORY_REBUILDs have
+                # diff_chars in 627-631 with old_system_chars == new_system_chars,
+                # which is the signature of pure attribute updates. The LLM does not
+                # act on these values (they are informational metadata), so skipping
+                # the rewrite is behaviour-equivalent for the model but eliminates
+                # the cache invalidation each one was causing. Gated to test user
+                # 92744418 first to verify no behaviour drift; follow-up PR removes
+                # the gate to graduate universally.
+                SKIP_TRIVIAL_REBUILD_USER_ID = "92744418"
+                if _mr_at_user_id == SKIP_TRIVIAL_REBUILD_USER_ID:
+                    try:
+                        import re as _re
+                        def _strip_volatile(text: str) -> str:
+                            text = _re.sub(r' chars_current="\d+"', "", text)
+                            text = _re.sub(r"Memory blocks were last modified: [^\n]+", "X", text)
+                            return text
+                        if _strip_volatile(curr_system_message_text) == _strip_volatile(new_system_message_str):
+                            try:
+                                import json as _json
+                                logger.info(
+                                    "[MEMORY_REBUILD_SKIPPED] %s",
+                                    _json.dumps({
+                                        "at_user_id": _mr_at_user_id,
+                                        "agent_id": agent_state.id,
+                                        "diff_chars": len(diff),
+                                        "system_chars": len(curr_system_message_text),
+                                        "reason": "volatile_attributes_only",
+                                    }, default=str),
+                                )
+                            except Exception:
+                                pass
+                            return in_context_messages
+                    except Exception:
+                        # If the volatile-detection itself errors, fall through to the
+                        # original rebuild path. Never block memory updates due to a
+                        # cache optimization.
+                        pass
+
                 # [DB Call] Update Messages
                 new_system_message = await self.message_manager.update_message_by_id_async(
                     curr_system_message.id, message_update=MessageUpdate(content=new_system_message_str), actor=self.actor


### PR DESCRIPTION
## Summary
In \`base_agent.py:_rebuild_memory_async\`, skip the system message rewrite when the only differences are 'volatile attribute' values that update on nearly every call but represent no semantic memory change. Gated to test user \`92744418\` first to verify behaviour, then graduate.

## The bug we found

PR #59 (observability expansion) added \`[MEMORY_REBUILD]\` event markers. Production logs show this pattern repeatedly across many users:

\`\`\`
diff_chars: 627, old_system_chars: 25537, new_system_chars: 25537  ← same size, small diff
diff_chars: 628, old_system_chars: 49464, new_system_chars: 49464
diff_chars: 629, old_system_chars: 22947, new_system_chars: 22947
diff_chars: 631, old_system_chars: 41119, new_system_chars: 41119
\`\`\`

When \`old_system_chars == new_system_chars\` and the diff is ~627, the system prompt's *content* didn't change — only metadata fields did:

1. **\`chars_current="N"\`** on each memory block header (\`<persona chars_current="8307" chars_max="50000">\`). Bumps by 1 digit any time the block grows by even a single character.
2. **The \`memory_edit_timestamp\`** line, refreshed on every rebuild attempt.

Both values update on nearly every call. The LLM does not act on either — they're informational metadata. **Yet each such rebuild persists a new system message to DB AND invalidates the entire downstream cache prefix** (persona block, human block, summary, rules block, messages-tail breakpoint). That's the dominant cost driver in our v2 cache path post-PR #61 graduation.

The early-return check at \`base_agent.py:102\` only catches *byte-identical* compile output, which fails when chars_current updates.

## The fix

After computing the diff, strip the volatile attributes from both old and new system message text. If the stripped versions match, the only changes were metadata — skip the rewrite.

\`\`\`python
def _strip_volatile(text: str) -> str:
    text = re.sub(r' chars_current="\d+"', '', text)
    text = re.sub(r'Memory blocks were last modified: [^\n]+', 'X', text)
    return text

if _strip_volatile(curr_system_message_text) == _strip_volatile(new_system_message_str):
    return in_context_messages  # skip rewrite + cache invalidation
\`\`\`

Critically:
- \`refresh_memory_async\` runs BEFORE this check, so agent_state.memory has the latest blocks regardless
- Any *real* content change (append, replace with different text, summary update) still falls through to the rewrite
- Only the chars_current attribute bump and timestamp refresh — the things the LLM never reads — are skipped

## Gating
\`if _mr_at_user_id == "92744418":\` — test user only. Lets us verify in observability that:
1. \`[MEMORY_REBUILD_SKIPPED]\` events fire at the expected rate (~50% of would-be rebuilds)
2. \`[MEMORY_REBUILD]\` events drop correspondingly (~50% reduction)
3. The test user's agent still recalls newly appended facts, doesn't redundantly re-append, doesn't lose context

After 1-2 hours of clean test-user behavior, follow-up PR removes the gate.

## Expected impact at full rollout
\`\`\`
~50% reduction in MEMORY_REBUILD-induced cache invalidations
× ~15k token average cache prefix invalidated
× ~10k events/hour at peak
× $3.75/M (Sonnet cache write rate)

= ~$5-8k/day cost reduction at 100% rollout
\`\`\`

## Behaviour risk
Near-zero, by design:
- The detection logic is targeted to KNOWN volatile patterns
- Anything not matching falls through to the rewrite path (existing behaviour)
- The volatile-detection itself is wrapped in try/except — any unexpected error falls through to rewrite, never blocks a legitimate memory update
- Agent's memory state (\`agent_state.memory\`) is independently refreshed by \`refresh_memory_async\` before this check runs

The LLM continues to see the same memory blocks. It just doesn't see chars_current incremented by 1 on every turn, or a fresh timestamp every call. Those weren't load-bearing for any agent decision.

## Test plan
- [ ] Merge and deploy
- [ ] Run a 20-30 turn conversation as test user \`92744418\` covering scenarios that would normally trigger persona mutations (sharing personal info, asking the agent to remember things, multi-topic conversations)
- [ ] Grep \`[MEMORY_REBUILD_SKIPPED]\` and \`[MEMORY_REBUILD]\` for that user
- [ ] **Verify:** \`[MEMORY_REBUILD_SKIPPED]\` events appear in roughly equal numbers to \`[MEMORY_REBUILD]\`
- [ ] **Verify:** Agent recalls names, dates, facts shared earlier in the conversation
- [ ] **Verify:** Agent does NOT redundantly re-append the same facts
- [ ] **Verify:** \`[CACHE_OBS_USAGE]\` for the test user shows fewer cold misses
- [ ] If all clean → follow-up PR removes the user_id gate

## Rollback
Single-commit revert. Returns to current behaviour where every memory change triggers a system message rewrite.

## Files changed
- \`letta/agents/base_agent.py\` (+44 / 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)