### PR TITLE
revert: roll v2 cache layout back to 0% (cost regression)

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -83,14 +83,18 @@ def _is_user_in_cache_obs_sample(at_user_id):
     except (ValueError, TypeError):
         return False
 
-# v2 cache-layout rollout: deterministic 50/50 split by at_user_id % MOD.
-# Users whose (int(at_user_id) % V2_CACHE_ROLLOUT_MOD) < V2_CACHE_ROLLOUT_BUCKET_MAX
-# get the v2 system-block layout + memory_metadata stabilization + messages-tail
-# cache_control. The other half stays on the v1 path.
-# Test user CACHE_OBS_USER_ID is always force-included so observability logs
-# remain comparable to the PR #54 baseline.
+# v2 cache-layout rollout: reverted to 0% after May 14 graduation regression.
+# Per-order cost rose from $0.314 (v1 baseline May 11) to $0.366 (+17%) on
+# May 14 when v2 went 100%. Anthropic API analysis: cache_creation share for
+# Sonnet 4.5 jumped 53% -> 71% the same hour as graduation, and the new
+# messages-tail breakpoint paired with mid-turn core_memory_append rebuilds
+# causes cascade cache invalidation (cache_read collapses to 2114 on ~30%
+# of calls, with 25-50k tokens of cache_creation per cold miss).
+# Setting BUCKET_MAX=0 sends all production users back to v1. Test user
+# CACHE_OBS_USER_ID stays on v2 (force-included below) so we can keep
+# v1-vs-v2 comparable in obs logs while we ship the cascade fix on v1.
 V2_CACHE_ROLLOUT_MOD = 10
-V2_CACHE_ROLLOUT_BUCKET_MAX = 10
+V2_CACHE_ROLLOUT_BUCKET_MAX = 0
 
 
 def _is_user_in_v2_cache_bucket(at_user_id):


### PR DESCRIPTION
## Why

v2 cache layout graduation (PR #61, May 14 12:52 UTC) caused a **17% per-order cost regression**. Anthropic admin API + Databricks order data:

| Date | Anthropic spend | Orders (consultant_type=99) | \$/order | vs May 11 baseline |
|---|---|---|---|---|
| **May 11 (v1)** | \$26,420 | 84,022 | **\$0.314** | — |
| May 13 (v2 50%) | \$28,459 | 84,506 | \$0.337 | +7.2% |
| **May 14 (v2 100%)** | \$30,643 | 83,643 | **\$0.366** | **+16.6%** |

Sonnet 4.5 cache_creation share jumped 53% → 71% in the exact hour of graduation. Cost of extra cache_writes (\$3.75/M) exceeded the gain from higher cache_reads (\$0.30/M vs \$3/M input) by 2x.

## Root cause (from PR #66 deep obs logs)

1000+ samples on 5% production traffic showed the cascade:

- v2 adds a 3rd cache breakpoint on the last assistant message in \`messages\`
- Letta's multi-step agent loop calls \`core_memory_append\` between LLM calls
- Each \`core_memory_append\` triggers \`_rebuild_memory_async\` on the next step
- Rebuild invalidates Entry B (everything past \`static_base\`) AND the messages-tail entry
- Result: \`cache_read\` collapses to ~2114 tokens on ~30% of sampled calls
- Per cold miss: 25-50k tokens of \`cache_creation\` at \$3.75/M

The cascade exists in v1 too, but v1's smaller cacheable surface (no messages tail, single-block system) makes each invalidation materially cheaper.

## Smoking gun trace (agent 21196fa2-5df2-..., Marina conversation)

\`\`\`
18:25:16  MEMORY_REBUILD  diff_chars=1056 (real persona update)
18:25:21  cache_read=23,724   cache_creation=11,666     ← step 1, Entry B hit
18:25:26  cache_read=2,114    cache_creation=44,973     ← step 2, FULL COLD MISS
                                                          (5 seconds later)
\`\`\`

## What this PR does

One-line flip: \`V2_CACHE_ROLLOUT_BUCKET_MAX = 10 → 0\`. Production goes to v1. Test user 92744418 stays on v2 (force-included) so we keep v1-vs-v2 visibility in \`CACHE_OBS\` logs.

## What stays in place

- Tool sort (PR #58) — universal, no harm signal
- Memory metadata hourly stabilizer — small, harmless
- All cache observability infra (REQ/USAGE/MISS_DIAG, agent_id wiring)
- Summarizer caching (PR #60) — separate code path

## Next PRs (in order)

1. **This PR** → expect \$/order back to ~\$0.314 within 60-90 min
2. **Defer mid-turn MEMORY_REBUILD** → fixes the actual cascade root cause on v1
3. **Graduate D1** (PR #65) → trivial-rebuild skip universal
4. **Re-introduce v2 system split** ONLY after cascade is verified fixed in v1, gated 5% → 25% → 100% with per-order kill criterion at each step
5. **Re-introduce messages-tail caching** as separate final PR

## Test plan

- [ ] Merge + Jenkins deploy
- [ ] T+60min: Anthropic admin API hourly query, Sonnet 4.5 cw_share should drop from ~71% back toward ~30%
- [ ] T+90min: Databricks \$/order check, target \$0.32 or lower
- [ ] CACHE_OBS samples should show v2_active=false for general users, true only for test user

🤖 Generated with [Claude Code](https://claude.com/claude-code)