### PR TITLE
feat: graduate system-message persistence filter to all users (PR α)

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -1130,11 +1130,11 @@ class LettaAgent(BaseAgent):
         # They are re-sent fresh on every call, so historical copies accumulate in DB and
         # grow input tokens O(N) per turn. Filtering them here stops the accumulation
         # without any behaviour change — the LLM still receives them for the current call.
-        # Gated to userId=92744418 for safe rollout.
-        if self.at_user_id == "92744418":
-            _persistable_initial = [m for m in (initial_messages or []) if m.role != MessageRole.system]
-        else:
-            _persistable_initial = initial_messages or []
+        # Validated for many days on userId=92744418 with no qualitative regression in
+        # 20-30 turn conversations. Graduating universally: stale system-event copies in
+        # history are noise that contradicts the fresh per-turn injections from go-ai-chat
+        # (e.g., yesterday's "current time is 2:30 PM" conflicting with today's fresh stamp).
+        _persistable_initial = [m for m in (initial_messages or []) if m.role != MessageRole.system]
         persisted_messages = await self.message_manager.create_many_messages_async(
             _persistable_initial + tool_call_messages, actor=self.actor
         )


### PR DESCRIPTION
## Summary

Graduates the test-user-only filter at \`letta_agent.py:1129-1140\` to all production users. Stops persisting role=system input messages (from go-ai-chat's per-turn sanity/date/clone-phase injections) into the messages table.

## Why this is the biggest single lever

Per PR #66 deep cache obs analysis, every Anthropic call carries 30-50 KB user-role messages — but the actual user-typed text is typically <500 chars. **The other 30-49 KB is accumulated stale system events from prior turns**, persisted from go-ai-chat's injections at:

| Source | Size | File:Line |
|---|---|---|
| \`sanityText\` | 2,200 chars | AiChatHandler.go:414-447 |
| \`reasoningSanityMessage\` | 1,454 chars | AiChatHandler.go:471 |
| \`expSanityMessage\` | 1,894 chars | AiChatHandler.go:479 |
| \`dateFollowText\` | ~400 chars | AiChatHandler.go:458 |
| \`remainingTime\` | ~250 chars (when enabled) | AiChatHandler.go:487 |
| \`clonePhase\` | ~250 chars (clones) | AiChatHandler.go:493 |
| \`kundali\` (filtered) | ~500-2,000 chars | kundali.go:31 |
| **Total per turn** | **~6-9 KB** | |

At turn 10, history carries ~60-80 KB of stale identical copies of these — which contradict the fresh per-turn stamps Letta re-injects every call.

## The change

\`\`\`diff
-if self.at_user_id == \"92744418\":
-    _persistable_initial = [m for m in (initial_messages or []) if m.role != MessageRole.system]
-else:
-    _persistable_initial = initial_messages or []
+_persistable_initial = [m for m in (initial_messages or []) if m.role != MessageRole.system]
\`\`\`

## Behavioural safety

**Current call**: unchanged. All system events still flow through \`initial_messages\` into the in-flight Anthropic request. The LLM sees fresh sanity / date / clone-phase / kundali every turn.

**Future calls**: history carries only role=user/assistant/tool messages. go-ai-chat re-injects the system events afresh from its own constructors every POST.

**What's removed**: stale historical copies of content that's already re-injected per turn. No semantic info lost.

## Evidence of safety

Test user 92744418 has been running with this filter for many days across 20-30 turn conversations. Manual review shows no qualitative regression. The filter behaves identically to a state where go-ai-chat had never sent the system messages in the first place.

## Expected impact

**Verifiable in 60 min post-deploy:**

1. \`CACHE_OBS_REQ\` \`messages_total_chars\` distribution shifts down (proves mechanic working)
2. \`CACHE_OBS_USAGE\` \`input_tokens\` (uncached) drops on calls from new conversations
3. Anthropic admin API hourly Sonnet 4.5 cost drops vs same-hour-yesterday baseline

**Steady-state cost reduction estimate**: 20-30% on Sonnet 4.5 once active conversations cycle through (most sessions are 7 min avg per Databricks, so steady state within 1-2 hours).

## Rollback

One-line revert. Existing persisted-pre-deploy bloat is not removed by this PR but will not grow further. Future conversations are immediately clean.

## Test plan
- [ ] Merge + Jenkins deploy
- [ ] T+15 min: grep \`[CACHE_OBS_REQ]\` for new agents (low \`input_message_count\`) — confirm \`messages_total_chars\` <5K for turn-1 calls
- [ ] T+30 min: compare \`messages_total_chars\` distribution to pre-deploy baseline
- [ ] T+60 min: Anthropic API hourly cost vs yesterday same hour
- [ ] T+90 min: spot-check 5-10 conversations for response quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)