### PR TITLE
Route Anthropic API key by business/geography for gated users

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -47,6 +47,113 @@ DUMMY_FIRST_USER_MESSAGE = "User initializing bootup sequence."
 # AND apply the v2 cache layout for that user only. Empty string disables both.
 CACHE_OBS_USER_ID = "92744418"
 
+# --- Geography / business-based API key routing ---
+# Only active for these test user IDs. Once validated, the set can be widened.
+_GEO_KEY_GATED_USER_IDS: frozenset = frozenset({"92744418", "54516480"})
+_AT_BUSINESS_ID = 1
+_PANDITJI_BUSINESS_ID = 10
+_LUMUS_BUSINESS_ID = 12
+
+
+def _select_geo_key_env(data: dict) -> Optional[str]:
+    """Return the env-var name for the Anthropic key that matches the user's
+    business/geography data. Returns None when the businessId is unrecognised."""
+    business_id = data.get("businessId")
+    if business_id == _PANDITJI_BUSINESS_ID:
+        return "ABC2_PANDITJI_ANTHROPIC_KEY"
+    if business_id == _LUMUS_BUSINESS_ID:
+        return "ABC2_LUMUS_ANTHROPIC_KEY"
+    if business_id == _AT_BUSINESS_ID:
+        if data.get("isForeign"):
+            return "ABC2_AT_FOREIGN_ANTHROPIC_KEY"
+        if data.get("isNative"):
+            return "ABC2_AT_NATIVE_ANTHROPIC_KEY"
+        return "ABC2_AT_INDIA_ANTHROPIC_KEY"
+    return None
+
+
+def _fetch_geo_api_key_sync(at_user_id: str) -> Optional[str]:
+    """Sync: fetch USER_STATIC_DATA from the chat-order Redis instance and
+    return the matching Anthropic API key value. Returns None on any failure."""
+    if at_user_id not in _GEO_KEY_GATED_USER_IDS:
+        return None
+    try:
+        import os
+        import redis as _redis_lib
+
+        host = os.environ.get("LETTA_1_REDIS_HOST")
+        password = os.environ.get("LETTA_1_REDIS_PASSWORD")
+        if not host:
+            return None
+        r = _redis_lib.Redis(
+            host=host, port=11641, username="default", password=password,
+            decode_responses=True, socket_connect_timeout=2, socket_timeout=2,
+        )
+        try:
+            raw = r.get(f"USER_STATIC_DATA_{at_user_id}")
+        finally:
+            r.close()
+        if not raw:
+            return None
+        data = json.loads(raw)
+        key_env = _select_geo_key_env(data)
+        if not key_env:
+            return None
+        key_value = os.environ.get(key_env)
+        if key_value:
+            get_logger(__name__).info(
+                "[GEO_KEY] user=%s businessId=%s isForeign=%s isNative=%s → %s",
+                at_user_id, data.get("businessId"), data.get("isForeign"), data.get("isNative"), key_env,
+            )
+        else:
+            get_logger(__name__).warning("[GEO_KEY] env var %s not set, using default key", key_env)
+        return key_value or None
+    except Exception as exc:
+        get_logger(__name__).warning("[GEO_KEY] sync lookup failed for user %s: %s", at_user_id, exc)
+        return None
+
+
+async def _fetch_geo_api_key_async(at_user_id: str) -> Optional[str]:
+    """Async: fetch USER_STATIC_DATA from the chat-order Redis instance and
+    return the matching Anthropic API key value. Returns None on any failure."""
+    if at_user_id not in _GEO_KEY_GATED_USER_IDS:
+        return None
+    try:
+        import os
+        import redis.asyncio as _aioredis
+
+        host = os.environ.get("LETTA_1_REDIS_HOST")
+        password = os.environ.get("LETTA_1_REDIS_PASSWORD")
+        if not host:
+            return None
+        r = _aioredis.Redis(
+            host=host, port=11641, username="default", password=password,
+            decode_responses=True, socket_connect_timeout=2, socket_timeout=2,
+        )
+        try:
+            raw = await r.get(f"USER_STATIC_DATA_{at_user_id}")
+        finally:
+            await r.aclose()
+        if not raw:
+            return None
+        data = json.loads(raw)
+        key_env = _select_geo_key_env(data)
+        if not key_env:
+            return None
+        key_value = os.environ.get(key_env)
+        if key_value:
+            get_logger(__name__).info(
+                "[GEO_KEY] user=%s businessId=%s isForeign=%s isNative=%s → %s",
+                at_user_id, data.get("businessId"), data.get("isForeign"), data.get("isNative"), key_env,
+            )
+        else:
+            get_logger(__name__).warning("[GEO_KEY] env var %s not set, using default key", key_env)
+        return key_value or None
+    except Exception as exc:
+        get_logger(__name__).warning("[GEO_KEY] async lookup failed for user %s: %s", at_user_id, exc)
+        return None
+
+
 logger = get_logger(__name__)
 
 
@@ -273,6 +380,11 @@ class AnthropicClient(LLMClientBase):
         if llm_config.provider_category == ProviderCategory.byok:
             override_key = ProviderManager().get_override_key(llm_config.provider_name, actor=self.actor)
 
+        if not override_key:
+            at_uid = getattr(self, "at_user_id", None)
+            if at_uid:
+                override_key = _fetch_geo_api_key_sync(at_uid)
+
         if async_client:
             return (
                 anthropic.AsyncAnthropic(api_key=override_key, max_retries=model_settings.anthropic_max_retries)
@@ -292,6 +404,11 @@ class AnthropicClient(LLMClientBase):
         override_key = None
         if llm_config.provider_category == ProviderCategory.byok:
             override_key = await ProviderManager().get_override_key_async(llm_config.provider_name, actor=self.actor)
+
+        if not override_key:
+            at_uid = getattr(self, "at_user_id", None)
+            if at_uid:
+                override_key = await _fetch_geo_api_key_async(at_uid)
 
         if async_client:
             return (

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -102,7 +102,7 @@ def _fetch_geo_api_key_sync(at_user_id: str) -> Optional[str]:
         key_value = os.environ.get(key_env)
         if key_value:
             get_logger(__name__).info(
-                "[GEO_KEY] user=%s businessId=%s isForeign=%s isNative=%s → %s",
+                "[GEO_KEY] user=%s businessId=%s isForeign=%s isNative=%s → env=%s",
                 at_user_id, data.get("businessId"), data.get("isForeign"), data.get("isNative"), key_env,
             )
         else:
@@ -143,7 +143,7 @@ async def _fetch_geo_api_key_async(at_user_id: str) -> Optional[str]:
         key_value = os.environ.get(key_env)
         if key_value:
             get_logger(__name__).info(
-                "[GEO_KEY] user=%s businessId=%s isForeign=%s isNative=%s → %s",
+                "[GEO_KEY] user=%s businessId=%s isForeign=%s isNative=%s → env=%s",
                 at_user_id, data.get("businessId"), data.get("isForeign"), data.get("isNative"), key_env,
             )
         else:


### PR DESCRIPTION
## Summary

- Adds Redis-based Anthropic API key routing in `letta/llm_api/anthropic_client.py`
- For gated user IDs (92744418, 54516480), fetches `USER_STATIC_DATA_{userId}` from
  the standalone chat-order Redis instance (LETTA_1_REDIS_HOST:11641) on every LLM
  request and selects the matching key:

  businessId=1 (AstroTalk)  isForeign → ABC2_AT_FOREIGN_ANTHROPIC_KEY
                             isNative  → ABC2_AT_NATIVE_ANTHROPIC_KEY
                             else      → ABC2_AT_INDIA_ANTHROPIC_KEY
  businessId=10 (Panditji)           → ABC2_PANDITJI_ANTHROPIC_KEY
  businessId=12 (Lumus)              → ABC2_LUMUS_ANTHROPIC_KEY

- All other users are unaffected — default ANTHROPIC_API_KEY continues as before
- Redis failures, missing env vars, unknown businessId → silent fallback to default
- Logs emit [GEO_KEY] lines with user ID, businessId, geography flags, and the
  env var name chosen — no key values are logged

## Test plan
- [ ] Confirm [GEO_KEY] log appears for user 92744418 / 54516480 with correct env= value
- [ ] Confirm all other users show no [GEO_KEY] log and use the default key
- [ ] Confirm requests continue normally when LETTA_1_REDIS_HOST is unset or Redis is down