### PR TITLE
Route Anthropic API key by business/geography via user_cohort request field

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -167,6 +167,7 @@ class LettaAgent(BaseAgent):
         use_vertex_experiment: bool = False,
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
+        user_cohort: Optional[str] = None,
     ) -> LettaResponse:
         agent_state = await self.agent_manager.get_agent_by_id_async(
             agent_id=self.agent_id, include_relationships=["tools", "memory", "tool_exec_environment_variables"], actor=self.actor
@@ -179,6 +180,7 @@ class LettaAgent(BaseAgent):
             use_vertex_experiment=use_vertex_experiment,
             use_bedrock_experiment=use_bedrock_experiment,
             model_override=model_override,
+            user_cohort=user_cohort,
         )
         return _create_letta_response(
             new_in_context_messages=new_in_context_messages,
@@ -199,6 +201,7 @@ class LettaAgent(BaseAgent):
         use_vertex_experiment: bool = False,
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
+        user_cohort: Optional[str] = None,
     ):
         agent_state = await self.agent_manager.get_agent_by_id_async(
             agent_id=self.agent_id, include_relationships=["tools", "memory", "tool_exec_environment_variables"], actor=self.actor
@@ -217,6 +220,7 @@ class LettaAgent(BaseAgent):
             put_inner_thoughts_first=True,
             actor=self.actor,
             at_user_id=self.at_user_id,
+            user_cohort=user_cohort,
         )
         stop_reason = None
         usage = LettaUsageStatistics()
@@ -369,6 +373,7 @@ class LettaAgent(BaseAgent):
         use_vertex_experiment: bool = False,
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
+        user_cohort: Optional[str] = None,
     ) -> Tuple[List[Message], List[Message], Optional[LettaStopReason], LettaUsageStatistics]:
         """
         Carries out an invocation of the agent loop. In each step, the agent
@@ -392,6 +397,7 @@ class LettaAgent(BaseAgent):
             put_inner_thoughts_first=True,
             actor=self.actor,
             at_user_id=self.at_user_id,
+            user_cohort=user_cohort,
         )
 
         # span for request
@@ -526,6 +532,7 @@ class LettaAgent(BaseAgent):
         use_vertex_experiment: bool = False,
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
+        user_cohort: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Carries out an invocation of the agent loop in a streaming fashion that yields partial tokens.
@@ -553,6 +560,7 @@ class LettaAgent(BaseAgent):
             put_inner_thoughts_first=True,
             actor=self.actor,
             at_user_id=self.at_user_id,
+            user_cohort=user_cohort,
         )
         stop_reason = None
         usage = LettaUsageStatistics()

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -117,116 +117,35 @@ def _is_user_in_v2_cache_bucket(at_user_id):
 # --- Geography / business-based API key routing ---
 # Only active for these test user IDs. Once validated, the set can be widened.
 _GEO_KEY_GATED_USER_IDS: frozenset = frozenset({"92744418", "54516480"})
-_AT_BUSINESS_ID = 1
-_PANDITJI_BUSINESS_ID = 10
-_LUMUS_BUSINESS_ID = 12
+
+_COHORT_TO_KEY_ENV: dict = {
+    "AT_NATIVE":  "ABC2_AT_NATIVE_ANTHROPIC_KEY",
+    "AT_FOREIGN": "ABC2_AT_FOREIGN_ANTHROPIC_KEY",
+    "INDIAN_AT":  "ABC2_AT_INDIA_ANTHROPIC_KEY",
+    "PANDITJI":   "ABC2_PANDITJI_ANTHROPIC_KEY",
+    "LUMUS":      "ABC2_LUMUS_ANTHROPIC_KEY",
+}
 
 
-def _select_geo_key_env(data: dict) -> Optional[str]:
-    """Return the env-var name for the Anthropic key that matches the user's
-    business/geography data. Returns None when the businessId is unrecognised."""
-    business_id = data.get("businessId")
-    if business_id == _PANDITJI_BUSINESS_ID:
-        return "ABC2_PANDITJI_ANTHROPIC_KEY"
-    if business_id == _LUMUS_BUSINESS_ID:
-        return "ABC2_LUMUS_ANTHROPIC_KEY"
-    if business_id == _AT_BUSINESS_ID:
-        if data.get("isForeign"):
-            return "ABC2_AT_FOREIGN_ANTHROPIC_KEY"
-        if data.get("isNative"):
-            return "ABC2_AT_NATIVE_ANTHROPIC_KEY"
-        return "ABC2_AT_INDIA_ANTHROPIC_KEY"
-    return None
-
-
-def _fetch_geo_api_key_sync(at_user_id: str) -> Optional[str]:
-    """Sync: fetch USER_STATIC_DATA from the chat-order Redis instance and
-    return the matching Anthropic API key value. Returns None on any failure."""
-    if at_user_id not in _GEO_KEY_GATED_USER_IDS:
-        get_logger(__name__).info("[GEO_KEY] user=%s not in gated set, skipping", at_user_id)
+def _resolve_key_from_cohort(at_user_id: Optional[str], user_cohort: Optional[str]) -> Optional[str]:
+    """Return the Anthropic API key value for the given cohort, or None to use the default.
+    Only applies for gated user IDs; UNKNOWN cohort and unrecognised values fall back to default."""
+    import os
+    if not at_user_id or at_user_id not in _GEO_KEY_GATED_USER_IDS:
         return None
-    try:
-        import os
-        import redis as _redis_lib
-
-        host = os.environ.get("LETTA_REDIS_HOST")
-        password = os.environ.get("LETTA_REDIS_PASSWORD")
-        if not host:
-            get_logger(__name__).warning("[GEO_KEY] LETTA_REDIS_HOST not set, using default key")
-            return None
-        r = _redis_lib.Redis(
-            host=host, port=11641, username="default", password=password,
-            decode_responses=True, socket_connect_timeout=2, socket_timeout=2,
-        )
-        try:
-            raw = r.get(f"USER_STATIC_DATA_{at_user_id}")
-        finally:
-            r.close()
-        if not raw:
-            get_logger(__name__).warning("[GEO_KEY] no Redis data for user=%s, using default key", at_user_id)
-            return None
-        data = json.loads(raw)
-        key_env = _select_geo_key_env(data)
-        if not key_env:
-            get_logger(__name__).warning("[GEO_KEY] unrecognised businessId=%s for user=%s, using default key", data.get("businessId"), at_user_id)
-            return None
-        key_value = os.environ.get(key_env)
-        if key_value:
-            get_logger(__name__).info(
-                "[GEO_KEY] user=%s businessId=%s isForeign=%s isNative=%s → env=%s",
-                at_user_id, data.get("businessId"), data.get("isForeign"), data.get("isNative"), key_env,
-            )
-        else:
-            get_logger(__name__).warning("[GEO_KEY] env var %s not set, using default key", key_env)
-        return key_value or None
-    except Exception as exc:
-        get_logger(__name__).warning("[GEO_KEY] sync lookup failed for user %s: %s", at_user_id, exc)
+    if not user_cohort or user_cohort == "UNKNOWN":
+        get_logger(__name__).warning("[GEO_KEY] user=%s cohort=UNKNOWN/missing, using default key", at_user_id)
         return None
-
-
-async def _fetch_geo_api_key_async(at_user_id: str) -> Optional[str]:
-    """Async: fetch USER_STATIC_DATA from the chat-order Redis instance and
-    return the matching Anthropic API key value. Returns None on any failure."""
-    if at_user_id not in _GEO_KEY_GATED_USER_IDS:
-        get_logger(__name__).info("[GEO_KEY] user=%s not in gated set, skipping", at_user_id)
+    key_env = _COHORT_TO_KEY_ENV.get(user_cohort)
+    if not key_env:
+        get_logger(__name__).warning("[GEO_KEY] user=%s unrecognised cohort=%s, using default key", at_user_id, user_cohort)
         return None
-    try:
-        import os
-        import redis.asyncio as _aioredis
-
-        host = os.environ.get("LETTA_REDIS_HOST")
-        password = os.environ.get("LETTA_REDIS_PASSWORD")
-        if not host:
-            get_logger(__name__).warning("[GEO_KEY] LETTA_REDIS_HOST not set, using default key")
-            return None
-        r = _aioredis.Redis(
-            host=host, port=11641, username="default", password=password,
-            decode_responses=True, socket_connect_timeout=2, socket_timeout=2,
-        )
-        try:
-            raw = await r.get(f"USER_STATIC_DATA_{at_user_id}")
-        finally:
-            await r.aclose()
-        if not raw:
-            get_logger(__name__).warning("[GEO_KEY] no Redis data for user=%s, using default key", at_user_id)
-            return None
-        data = json.loads(raw)
-        key_env = _select_geo_key_env(data)
-        if not key_env:
-            get_logger(__name__).warning("[GEO_KEY] unrecognised businessId=%s for user=%s, using default key", data.get("businessId"), at_user_id)
-            return None
-        key_value = os.environ.get(key_env)
-        if key_value:
-            get_logger(__name__).info(
-                "[GEO_KEY] user=%s businessId=%s isForeign=%s isNative=%s → env=%s",
-                at_user_id, data.get("businessId"), data.get("isForeign"), data.get("isNative"), key_env,
-            )
-        else:
-            get_logger(__name__).warning("[GEO_KEY] env var %s not set, using default key", key_env)
-        return key_value or None
-    except Exception as exc:
-        get_logger(__name__).warning("[GEO_KEY] async lookup failed for user %s: %s", at_user_id, exc)
-        return None
+    key_value = os.environ.get(key_env)
+    if key_value:
+        get_logger(__name__).info("[GEO_KEY] user=%s cohort=%s → env=%s", at_user_id, user_cohort, key_env)
+    else:
+        get_logger(__name__).warning("[GEO_KEY] user=%s cohort=%s env var %s not set, using default key", at_user_id, user_cohort, key_env)
+    return key_value or None
 
 
 logger = get_logger(__name__)
@@ -457,8 +376,9 @@ class AnthropicClient(LLMClientBase):
 
         if not override_key:
             at_uid = getattr(self, "at_user_id", None)
-            if at_uid:
-                override_key = _fetch_geo_api_key_sync(at_uid)
+            cohort = getattr(self, "user_cohort", None)
+            logger.info("[GEO_KEY] _get_anthropic_client at_user_id=%s user_cohort=%s", at_uid, cohort)
+            override_key = _resolve_key_from_cohort(at_uid, cohort)
 
         if async_client:
             return (
@@ -482,9 +402,9 @@ class AnthropicClient(LLMClientBase):
 
         if not override_key:
             at_uid = getattr(self, "at_user_id", None)
-            logger.info("[GEO_KEY] _get_anthropic_client_async at_user_id=%s", at_uid)
-            if at_uid:
-                override_key = await _fetch_geo_api_key_async(at_uid)
+            cohort = getattr(self, "user_cohort", None)
+            logger.info("[GEO_KEY] _get_anthropic_client_async at_user_id=%s user_cohort=%s", at_uid, cohort)
+            override_key = _resolve_key_from_cohort(at_uid, cohort)
 
         if async_client:
             return (

--- a/letta/llm_api/llm_client.py
+++ b/letta/llm_api/llm_client.py
@@ -16,6 +16,7 @@ class LLMClient:
         put_inner_thoughts_first: bool = True,
         actor: Optional["User"] = None,
         at_user_id: Optional[str] = None,
+        user_cohort: Optional[str] = None,
     ) -> Optional[LLMClientBase]:
         """
         Create an LLM client based on the model endpoint type.
@@ -54,6 +55,7 @@ class LLMClient:
                     put_inner_thoughts_first=put_inner_thoughts_first,
                     actor=actor,
                     at_user_id=at_user_id,
+                    user_cohort=user_cohort,
                 )
             case ProviderType.openai | ProviderType.together:
                 from letta.llm_api.openai_client import OpenAIClient

--- a/letta/llm_api/llm_client_base.py
+++ b/letta/llm_api/llm_client_base.py
@@ -31,9 +31,11 @@ class LLMClientBase:
         use_tool_naming: bool = True,
         actor: Optional["User"] = None,
         at_user_id: Optional[str] = None,
+        user_cohort: Optional[str] = None,
     ):
         self.actor = actor
         self.at_user_id = at_user_id
+        self.user_cohort = user_cohort
         self.put_inner_thoughts_first = put_inner_thoughts_first
         self.use_tool_naming = use_tool_naming
 

--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -46,6 +46,16 @@ class LettaRequest(BaseModel):
         description="Optional model name to use for this request only, overriding the agent's configured llm_config.model. Useful for runtime A/B testing (e.g. shifting an agent from Sonnet 4.5 to Sonnet 4.6 without modifying the stored agent config).",
     )
 
+    user_cohort: Optional[str] = Field(
+        default=None,
+        description="User cohort for API key routing. One of: AT_NATIVE, AT_FOREIGN, INDIAN_AT, PANDITJI, LUMUS, UNKNOWN. Populated by the upstream service from Redis USER_STATIC_DATA_{userId}.",
+    )
+
+    business_id: Optional[int] = Field(
+        default=None,
+        description="Raw business ID from the order (1=AstroTalk, 10=Panditji, 12=Lumus). 0 when unavailable.",
+    )
+
 
 class LettaStreamingRequest(LettaRequest):
     stream_tokens: bool = Field(

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -721,6 +721,7 @@ async def send_message(
             use_vertex_experiment=request.use_vertex_experiment,
             use_bedrock_experiment=request.use_bedrock_experiment,
             model_override=request.model_override,
+            user_cohort=request.user_cohort,
         )
     else:
         result = await server.send_message_to_agent(
@@ -737,6 +738,7 @@ async def send_message(
             use_vertex_experiment=request.use_vertex_experiment,
             use_bedrock_experiment=request.use_bedrock_experiment,
             model_override=request.model_override,
+            user_cohort=request.user_cohort,
         )
     return result
 
@@ -821,6 +823,7 @@ async def send_message_streaming(
                     use_vertex_experiment=request.use_vertex_experiment,
                     use_bedrock_experiment=request.use_bedrock_experiment,
                     model_override=request.model_override,
+                    user_cohort=request.user_cohort,
                 ),
                 media_type="text/event-stream",
             )
@@ -835,6 +838,7 @@ async def send_message_streaming(
                     use_vertex_experiment=request.use_vertex_experiment,
                     use_bedrock_experiment=request.use_bedrock_experiment,
                     model_override=request.model_override,
+                    user_cohort=request.user_cohort,
                 ),
                 media_type="text/event-stream",
             )
@@ -854,6 +858,7 @@ async def send_message_streaming(
             use_vertex_experiment=request.use_vertex_experiment,
             use_bedrock_experiment=request.use_bedrock_experiment,
             model_override=request.model_override,
+            user_cohort=request.user_cohort,
         )
 
     return result

--- a/letta/server/server.py
+++ b/letta/server/server.py
@@ -2247,6 +2247,7 @@ class SyncServer(Server):
         use_vertex_experiment: bool = False,
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
+        user_cohort: Optional[str] = None,
     ) -> Union[StreamingResponse, LettaResponse]:
         """Split off into a separate function so that it can be imported in the /chat/completion proxy."""
         # TODO: @charles is this the correct way to handle?


### PR DESCRIPTION
## Summary

- Adds `user_cohort` and `business_id` fields to `LettaRequest` (POST /v1/agents/{id}/messages body)
- Upstream go-ai-chat service populates `user_cohort` from Redis `USER_STATIC_DATA_{userId}` — Letta no longer queries Redis itself
- Threads `user_cohort` from the request body through to `AnthropicClient` and selects the matching API key:

  | user_cohort  | Env var                      |
  |--------------|------------------------------|
  | AT_NATIVE    | ABC2_AT_NATIVE_ANTHROPIC_KEY |
  | AT_FOREIGN   | ABC2_AT_FOREIGN_ANTHROPIC_KEY|
  | INDIAN_AT    | ABC2_AT_INDIA_ANTHROPIC_KEY  |
  | PANDITJI     | ABC2_PANDITJI_ANTHROPIC_KEY  |
  | LUMUS        | ABC2_LUMUS_ANTHROPIC_KEY     |
  | UNKNOWN/missing | default ANTHROPIC_API_KEY |

- Gated to user IDs 92744418 and 54516480 for now
- All fallback cases (missing cohort, UNKNOWN, unset env var, non-gated user) return None and fall through to the default key — nothing breaks

## Files changed
- `letta/schemas/letta_request.py` — new fields
- `letta/server/rest_api/routers/v1/agents.py` — thread user_cohort through both endpoints
- `letta/server/server.py` — add user_cohort param to send_message_to_agent
- `letta/agents/letta_agent.py` — add to step / _step / step_stream_no_tokens / step_stream + LLMClient.create
- `letta/llm_api/llm_client.py` — add user_cohort param
- `letta/llm_api/llm_client_base.py` — store as self.user_cohort
- `letta/llm_api/anthropic_client.py` — replace Redis helpers with _resolve_key_from_cohort()

## Test plan
- [ ] Send request with user_cohort=INDIAN_AT for user 92744418, confirm log: `[GEO_KEY] user=92744418 cohort=INDIAN_AT → env=ABC2_AT_INDIA_ANTHROPIC_KEY`
- [ ] Send request without user_cohort, confirm no [GEO_KEY] success log and default key is used
- [ ] Confirm requests for all other users are unaffected