### PR TITLE
revert: restore test-user gate on mid-turn rebuild skip (PR #77 rollback)

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -941,18 +941,25 @@ class LettaAgent(BaseAgent):
         # PR β cascade fix: skip _rebuild_memory_async on intermediate steps of the
         # same user turn. The agent multi-step loop calls core_memory_append between
         # LLM calls, which used to trigger a rebuild every step and invalidate the
-        # system-prompt cache. Validated on test user 92744418 in a 20+ turn
-        # conversation: REBUILD_SKIPPED_MID_TURN fires cleanly, response quality
-        # unchanged. Cache_read stays elevated on 12 of 14 sampled calls vs the
-        # prior baseline where every other call collapsed to ~2114 tokens.
-        # Graduating universally. Memory state still persists in DB; the LLM that
-        # just called core_memory_append already has the appended content in its
-        # own assistant message — it does not need a refreshed system block to
-        # function correctly.
-        # NOTE: there is a separate cascade source via core_memory_append's tool
-        # executor path (update_memory_if_changed_async → rebuild_system_prompt_async)
-        # which this PR does not address. Follow-up PR will gate that path.
-        skip_rebuild = step_index > 0
+        # system-prompt cache.
+        #
+        # ROLLED BACK to test-user-only after universal graduation (PR #77) showed
+        # cost-per-minute +2.9% vs pre-graduation in a clean traffic-normalized
+        # comparison (₹3.96/min → ₹4.07/min, 20h post-grad). The reason: the
+        # tool-executor path (core_memory_append → update_memory_if_changed_async
+        # → rebuild_system_prompt_async) rebuilds system prompt DURING tool
+        # execution, independent of this code path. Skipping the agent-loop
+        # rebuild without also gating the tool-executor rebuild causes a second-
+        # order effect where the next user turn's rebuild has a bigger
+        # accumulated diff, hurting cache more on subsequent turns.
+        #
+        # Restoring test-user gate while we ship the tool-executor cascade fix
+        # (next PR). Will re-graduate this together with that fix once both
+        # paths skip in coordinated fashion.
+        skip_rebuild = (
+            self.at_user_id == "92744418"
+            and step_index > 0
+        )
         if skip_rebuild:
             try:
                 import json as _json


### PR DESCRIPTION
## Summary

Rolls back PR #77 (mid-turn rebuild skip graduated universal) after traffic-normalized 20-hour measurement showed +2.9% cost-per-minute regression. Test user 92744418 still gets the skip; everyone else returns to the prior baseline behavior.

## Measured regression

Traffic-normalized comparison (May 18 13:00 UTC → May 20 04:00 UTC, 40h total, on stable 50/50 Anthropic/Bedrock split):

| Metric | Pre-grad (19h) | Post-grad (21h) | Δ |
|---|---|---|---|
| Anthropic cost | $9,476 | $11,019 | — |
| Traffic | 20,927 min/hr | 21,386 min/hr | +2% (negligible) |
| **Cost per minute (total ×2 for Bedrock)** | **₹3.96/min** | **₹4.07/min** | **+₹0.12 (+2.9%)** |
| Sonnet hit rate | 45.2% | 46.4% | +1.2pp |

Traffic was within 2% — this is not a traffic effect. It's a real per-call cost increase.

## Why the regression

There is a SECOND cascade source independent of \`_rebuild_memory_async\`:

\`letta/services/tool_executor/core_tool_executor.py:202\`:
\`\`\`python
async def core_memory_append(self, ...) -> Optional[str]:
    agent_state.memory.update_block_value(label=label, value=new_value)
    await AgentManager().update_memory_if_changed_async(agent_id=agent_state.id, ...)
    # ^ internally calls rebuild_system_prompt_async, which writes new system to DB
\`\`\`

This tool-executor rebuild fires INSIDE tool execution. PR #77's skip happens AFTER this tool path has already mutated the DB system message.

The second-order effect: skipping the agent-loop rebuild on intermediate steps means the next user turn's rebuild encounters a LARGER accumulated diff. That bigger diff hits cache harder than the smaller per-step normalizations would have.

## Diff

One-line restore of the gate:

\`\`\`diff
-skip_rebuild = step_index > 0
+skip_rebuild = (
+    self.at_user_id == \"92744418\"
+    and step_index > 0
+)
\`\`\`

## Plan after this revert

1. **Merge this revert** → clean v1+α baseline restored
2. **Ship PR γ** (tool-executor cascade fix): gate the tool-executor rebuild similarly during multi-step agent loops
3. **Re-graduate the mid-turn skip TOGETHER with PR γ** so both rebuild paths skip in coordinated fashion
4. **Expected combined impact:** ₹1-1.5 cr/month from the coordinated fix (vs ₹0 from PR β alone)

## Risk

Low. One-line revert. Test user 92744418 keeps the skip for continued validation of the code path.

## Test plan
- [ ] Merge + Jenkins deploy
- [ ] T+30 min: confirm \`[REBUILD_SKIPPED_MID_TURN]\` only fires for user 92744418
- [ ] T+24h: traffic-normalized cost-per-minute returns to ₹3.96/min baseline
- [ ] No quality regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)