### PR TITLE
feat: forward per-request thinking and output_config to Claude API

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -168,6 +168,8 @@ class LettaAgent(BaseAgent):
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
         user_cohort: Optional[str] = None,
+        thinking: Optional[dict] = None,
+        output_config: Optional[dict] = None,
     ) -> LettaResponse:
         agent_state = await self.agent_manager.get_agent_by_id_async(
             agent_id=self.agent_id, include_relationships=["tools", "memory", "tool_exec_environment_variables"], actor=self.actor
@@ -181,6 +183,8 @@ class LettaAgent(BaseAgent):
             use_bedrock_experiment=use_bedrock_experiment,
             model_override=model_override,
             user_cohort=user_cohort,
+            thinking=thinking,
+            output_config=output_config,
         )
         return _create_letta_response(
             new_in_context_messages=new_in_context_messages,
@@ -202,6 +206,8 @@ class LettaAgent(BaseAgent):
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
         user_cohort: Optional[str] = None,
+        thinking: Optional[dict] = None,
+        output_config: Optional[dict] = None,
     ):
         agent_state = await self.agent_manager.get_agent_by_id_async(
             agent_id=self.agent_id, include_relationships=["tools", "memory", "tool_exec_environment_variables"], actor=self.actor
@@ -246,6 +252,8 @@ class LettaAgent(BaseAgent):
                     use_vertex_experiment=use_vertex_experiment,
                     use_bedrock_experiment=use_bedrock_experiment,
                     step_index=i,
+                    thinking=thinking,
+                    output_config=output_config,
                 )
             )
             in_context_messages = current_in_context_messages + new_in_context_messages
@@ -375,6 +383,8 @@ class LettaAgent(BaseAgent):
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
         user_cohort: Optional[str] = None,
+        thinking: Optional[dict] = None,
+        output_config: Optional[dict] = None,
     ) -> Tuple[List[Message], List[Message], Optional[LettaStopReason], LettaUsageStatistics]:
         """
         Carries out an invocation of the agent loop. In each step, the agent
@@ -415,7 +425,9 @@ class LettaAgent(BaseAgent):
 
             request_data, response_data, current_in_context_messages, new_in_context_messages, valid_tool_names = (
                 await self._build_and_request_from_llm(
-                    current_in_context_messages, new_in_context_messages, agent_state, llm_client, tool_rules_solver, agent_step_span, use_vertex_experiment=use_vertex_experiment, use_bedrock_experiment=use_bedrock_experiment, step_index=i
+                    current_in_context_messages, new_in_context_messages, agent_state, llm_client, tool_rules_solver, agent_step_span,
+                    use_vertex_experiment=use_vertex_experiment, use_bedrock_experiment=use_bedrock_experiment, step_index=i,
+                    thinking=thinking, output_config=output_config,
                 )
             )
             in_context_messages = current_in_context_messages + new_in_context_messages
@@ -534,6 +546,8 @@ class LettaAgent(BaseAgent):
         use_bedrock_experiment: bool = False,
         model_override: Optional[str] = None,
         user_cohort: Optional[str] = None,
+        thinking: Optional[dict] = None,
+        output_config: Optional[dict] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Carries out an invocation of the agent loop in a streaming fashion that yields partial tokens.
@@ -593,6 +607,8 @@ class LettaAgent(BaseAgent):
                 llm_client,
                 tool_rules_solver,
                 step_index=i,
+                thinking=thinking,
+                output_config=output_config,
             )
             log_event("agent.stream.llm_response.received")  # [3^]
 
@@ -757,6 +773,8 @@ class LettaAgent(BaseAgent):
         use_vertex_experiment: bool = False,
         use_bedrock_experiment: bool = False,
         step_index: int = 0,
+        thinking: Optional[dict] = None,
+        output_config: Optional[dict] = None,
     ) -> Tuple[Dict, Dict, List[Message], List[Message], List[str]] | None:
         for attempt in range(self.max_summarization_retries + 1):
             try:
@@ -770,6 +788,15 @@ class LettaAgent(BaseAgent):
                     step_index=step_index,
                 )
                 log_event("agent.stream_no_tokens.llm_request.created")
+
+                # Inject per-request thinking/output_config overrides
+                if thinking is not None:
+                    request_data["thinking"] = thinking
+                    request_data["temperature"] = 1.0
+                    if request_data.get("max_tokens", 0) < 8000:
+                        request_data["max_tokens"] = 8000
+                if output_config is not None:
+                    request_data["output_config"] = output_config
 
                 async with AsyncTimer() as timer:
                     # Attempt LLM request
@@ -811,6 +838,8 @@ class LettaAgent(BaseAgent):
         llm_client: LLMClientBase,
         tool_rules_solver: ToolRulesSolver,
         step_index: int = 0,
+        thinking: Optional[dict] = None,
+        output_config: Optional[dict] = None,
     ) -> Tuple[Dict, AsyncStream[ChatCompletionChunk], List[Message], List[Message], List[str], int] | None:
         for attempt in range(self.max_summarization_retries + 1):
             try:
@@ -824,6 +853,15 @@ class LettaAgent(BaseAgent):
                     step_index=step_index,
                 )
                 log_event("agent.stream.llm_request.created")  # [2^]
+
+                # Inject per-request thinking/output_config overrides
+                if thinking is not None:
+                    request_data["thinking"] = thinking
+                    request_data["temperature"] = 1.0
+                    if request_data.get("max_tokens", 0) < 8000:
+                        request_data["max_tokens"] = 8000
+                if output_config is not None:
+                    request_data["output_config"] = output_config
 
                 provider_request_start_timestamp_ns = get_utc_timestamp_ns()
                 if first_chunk and ttft_span is not None:

--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -57,6 +57,11 @@ from letta.utils import log_telemetry, validate_function_response
 logger = get_logger(__name__)
 
 
+# Per-request thinking/output_config forwarding is gated to these user IDs.
+# Expand once validated.
+_THINKING_GATED_USER_IDS: frozenset = frozenset({"92744418"})
+
+
 class LettaAgent(BaseAgent):
 
     def __init__(
@@ -789,14 +794,15 @@ class LettaAgent(BaseAgent):
                 )
                 log_event("agent.stream_no_tokens.llm_request.created")
 
-                # Inject per-request thinking/output_config overrides
-                if thinking is not None:
-                    request_data["thinking"] = thinking
-                    request_data["temperature"] = 1.0
-                    if request_data.get("max_tokens", 0) < 8000:
-                        request_data["max_tokens"] = 8000
-                if output_config is not None:
-                    request_data["output_config"] = output_config
+                # Inject per-request thinking/output_config overrides (gated)
+                if self.at_user_id in _THINKING_GATED_USER_IDS:
+                    if thinking is not None:
+                        request_data["thinking"] = thinking
+                        request_data["temperature"] = 1.0
+                        if request_data.get("max_tokens", 0) < 8000:
+                            request_data["max_tokens"] = 8000
+                    if output_config is not None:
+                        request_data["output_config"] = output_config
 
                 async with AsyncTimer() as timer:
                     # Attempt LLM request
@@ -854,14 +860,15 @@ class LettaAgent(BaseAgent):
                 )
                 log_event("agent.stream.llm_request.created")  # [2^]
 
-                # Inject per-request thinking/output_config overrides
-                if thinking is not None:
-                    request_data["thinking"] = thinking
-                    request_data["temperature"] = 1.0
-                    if request_data.get("max_tokens", 0) < 8000:
-                        request_data["max_tokens"] = 8000
-                if output_config is not None:
-                    request_data["output_config"] = output_config
+                # Inject per-request thinking/output_config overrides (gated)
+                if self.at_user_id in _THINKING_GATED_USER_IDS:
+                    if thinking is not None:
+                        request_data["thinking"] = thinking
+                        request_data["temperature"] = 1.0
+                        if request_data.get("max_tokens", 0) < 8000:
+                            request_data["max_tokens"] = 8000
+                    if output_config is not None:
+                        request_data["output_config"] = output_config
 
                 provider_request_start_timestamp_ns = get_utc_timestamp_ns()
                 if first_chunk and ttft_span is not None:

--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -56,6 +56,16 @@ class LettaRequest(BaseModel):
         description="Raw business ID from the order (1=AstroTalk, 10=Panditji, 12=Lumus). 0 when unavailable.",
     )
 
+    thinking: Optional[dict] = Field(
+        default=None,
+        description="Extended thinking config forwarded to the Claude API (e.g. {'type': 'adaptive'}). When set, temperature is forced to 1 and max_tokens is raised to at least 8000.",
+    )
+
+    output_config: Optional[dict] = Field(
+        default=None,
+        description="Output config forwarded to the Claude API (e.g. {'effort': 'high'}).",
+    )
+
 
 class LettaStreamingRequest(LettaRequest):
     stream_tokens: bool = Field(

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -722,6 +722,8 @@ async def send_message(
             use_bedrock_experiment=request.use_bedrock_experiment,
             model_override=request.model_override,
             user_cohort=request.user_cohort,
+            thinking=request.thinking,
+            output_config=request.output_config,
         )
     else:
         result = await server.send_message_to_agent(
@@ -824,6 +826,8 @@ async def send_message_streaming(
                     use_bedrock_experiment=request.use_bedrock_experiment,
                     model_override=request.model_override,
                     user_cohort=request.user_cohort,
+                    thinking=request.thinking,
+                    output_config=request.output_config,
                 ),
                 media_type="text/event-stream",
             )
@@ -839,6 +843,8 @@ async def send_message_streaming(
                     use_bedrock_experiment=request.use_bedrock_experiment,
                     model_override=request.model_override,
                     user_cohort=request.user_cohort,
+                    thinking=request.thinking,
+                    output_config=request.output_config,
                 ),
                 media_type="text/event-stream",
             )


### PR DESCRIPTION
go-ai-chat sends optional `thinking` and `output_config` fields in the /v1/agents/{id}/messages request body. This change parses them from the incoming request and forwards them verbatim to the upstream Claude API call, enforcing temperature=1 and min max_tokens=8000 when thinking is active (both required by the API).

Response parsing already handles the resulting `thinking` content block by type-filtering to `text` only — no change needed there.

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/letta-ai/letta/issues) or [PRs](https://github.com/letta-ai/letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
