### PR TITLE
Graduate output_config forwarding to all users

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -794,15 +794,16 @@ class LettaAgent(BaseAgent):
                 )
                 log_event("agent.stream_no_tokens.llm_request.created")
 
-                # Inject per-request thinking/output_config overrides (gated)
+                # Inject per-request thinking overrides (gated)
                 if self.at_user_id in _THINKING_GATED_USER_IDS:
                     if thinking is not None:
                         request_data["thinking"] = thinking
                         request_data["temperature"] = 1.0
                         if request_data.get("max_tokens", 0) < 8000:
                             request_data["max_tokens"] = 8000
-                    if output_config is not None:
-                        request_data["output_config"] = output_config
+                # output_config flows to all users unconditionally
+                if output_config is not None:
+                    request_data["output_config"] = output_config
 
                 async with AsyncTimer() as timer:
                     # Attempt LLM request
@@ -860,15 +861,16 @@ class LettaAgent(BaseAgent):
                 )
                 log_event("agent.stream.llm_request.created")  # [2^]
 
-                # Inject per-request thinking/output_config overrides (gated)
+                # Inject per-request thinking overrides (gated)
                 if self.at_user_id in _THINKING_GATED_USER_IDS:
                     if thinking is not None:
                         request_data["thinking"] = thinking
                         request_data["temperature"] = 1.0
                         if request_data.get("max_tokens", 0) < 8000:
                             request_data["max_tokens"] = 8000
-                    if output_config is not None:
-                        request_data["output_config"] = output_config
+                # output_config flows to all users unconditionally
+                if output_config is not None:
+                    request_data["output_config"] = output_config
 
                 provider_request_start_timestamp_ns = get_utc_timestamp_ns()
                 if first_chunk and ttft_span is not None:

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -299,6 +299,8 @@ class AnthropicClient(LLMClientBase):
                 bedrock_body["stop_sequences"] = request_data["stop_sequences"]
             if "thinking" in request_data:
                 bedrock_body["thinking"] = request_data["thinking"]
+            if "output_config" in request_data:
+                bedrock_body["output_config"] = request_data["output_config"]
 
             print(f"DEBUG: [AnthropicClient] Calling bedrock invoke_model with modelId={model_id}")
 


### PR DESCRIPTION
## Summary

- Removes the `_THINKING_GATED_USER_IDS` gate for `output_config` in both
  `_build_and_request_from_llm` and `_build_and_request_from_llm_streaming` —
  the field now flows into `request_data` for every user when present in the
  request body
- The `thinking` override (which side-effects temperature and max_tokens)
  remains gated as before
- Adds `output_config` to the Bedrock explicit-whitelist body in
  `anthropic_client.py` so it isn't silently dropped on that path
  (standard Anthropic and Vertex already use `**request_data`)
- No behaviour change when `output_config` is absent — both injection points
  are guarded by `if output_config is not None`
