### PR TITLE
 feat: forward output_config to Anthropic API with thinking + tool_choice compatibility

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -801,6 +801,9 @@ class LettaAgent(BaseAgent):
                         request_data["temperature"] = 1.0
                         if request_data.get("max_tokens", 0) < 8000:
                             request_data["max_tokens"] = 8000
+                        # Thinking is incompatible with tool_choice "any"/"tool"; downgrade to "auto"
+                        if request_data.get("tool_choice", {}).get("type") in ("any", "tool"):
+                            request_data["tool_choice"] = {"type": "auto", "disable_parallel_tool_use": True}
                 # output_config flows to all users unconditionally
                 if output_config is not None:
                     request_data["output_config"] = output_config
@@ -869,6 +872,9 @@ class LettaAgent(BaseAgent):
                         request_data["temperature"] = 1.0
                         if request_data.get("max_tokens", 0) < 8000:
                             request_data["max_tokens"] = 8000
+                        # Thinking is incompatible with tool_choice "any"/"tool"; downgrade to "auto"
+                        if request_data.get("tool_choice", {}).get("type") in ("any", "tool"):
+                            request_data["tool_choice"] = {"type": "auto", "disable_parallel_tool_use": True}
                 # output_config flows to all users unconditionally
                 if output_config is not None:
                     request_data["output_config"] = output_config


### PR DESCRIPTION
## What changed and why

### 1. `output_config` forwarding — ungated for all users
`output_config` (e.g. `{"effort": "high"}`) can now be sent in any request
body and will reach the Anthropic API. Previously it was gated behind a
single test user ID (`_THINKING_GATED_USER_IDS`). The gate made sense for
`thinking` (which has side-effects on temperature and max_tokens) but not
for `output_config` which is a pure pass-through with no side-effects.

### 2. `output_config` via `extra_body` — bypass SDK kwarg validation
The Anthropic Python SDK rejects `output_config` as an unknown top-level
kwarg (`AsyncMessages.create() got an unexpected keyword argument
'output_config'`). The raw Anthropic HTTP API accepts it fine (verified
with direct curl). Fix: extract `output_config` from `request_data` and
inject it via `extra_body`, which merges it into the raw JSON body without
SDK type validation. Applied to all three SDK call sites:
- Standard Anthropic (`beta.messages.create`)
- Vertex (`messages.create`)
- Streaming (`stream_async`)

Bedrock builds the body manually with an explicit whitelist — `output_config`
added there directly.

### 3. `tool_choice` "any" → "auto" when thinking is injected
Anthropic hard-blocks thinking when `tool_choice` forces tool use
(`"any"` or `"tool"`). Letta sets `tool_choice: "any"` by default
(driven by `put_inner_thoughts_in_kwargs=True`) so every per-request
thinking injection was failing with:
> `Thinking may not be enabled when tool_choice forces tool use`

Fix: when the per-request `thinking` override is injected, downgrade
`tool_choice` from `"any"` → `"auto"`. This matches what upstream
`letta-ai/letta` does inside `build_request_data` for `enable_reasoner`
models.

**Risk of "auto":** the model is no longer guaranteed to call a tool.
Mitigated by the existing fallback in `letta_agent.py` (lines 280–293)
which detects a plain-text response and wraps it in a synthetic
`send_message` call — the user always gets a reply and a warning is
logged.

## Zero behaviour change when params are absent
- `output_config` absent → nothing added to `request_data`, `extra_body`
  never passed, SDK call identical to before
- `thinking` absent → `tool_choice` unchanged, stays `"any"` as before

## Files changed
- `letta/agents/letta_agent.py` — ungate `output_config`; downgrade
  `tool_choice` when thinking is injected (both step paths)
- `letta/llm_api/anthropic_client.py` — `extra_body` for `output_config`
  on all SDK call sites; `output_config` in Bedrock body whitelist

## Test
```bash
curl .../v1/agents/<id>/messages \
  -d '{"messages":[...],"thinking":{"type":"adaptive"},"output_config":{"effort":"high"}}'