### PR TITLE
fix: derive budget_tokens from max_tokens on Bedrock adaptive→enabled…

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -309,10 +309,16 @@ class AnthropicClient(LLMClientBase):
                 _supports_thinking = "claude-sonnet-4-6" in _requested_model or "claude-opus-4-6" in _requested_model
                 if _supports_thinking:
                     _thinking_val = request_data["thinking"]
-                    # Bedrock does not support {"type": "adaptive"} — convert to enabled with a budget
+                    # Bedrock does not support {"type": "adaptive"} — convert to enabled with a budget.
+                    # budget_tokens must be strictly less than max_tokens (Bedrock requirement).
                     if isinstance(_thinking_val, dict) and _thinking_val.get("type") == "adaptive":
-                        _thinking_val = {"type": "enabled", "budget_tokens": 8000}
-                        logger.warning("[BEDROCK] Converted adaptive thinking to enabled (budget_tokens=8000) — Bedrock does not support adaptive type")
+                        _max_tokens = bedrock_body.get("max_tokens", 4096)
+                        _budget_tokens = max(1024, _max_tokens - 1000)
+                        _thinking_val = {"type": "enabled", "budget_tokens": _budget_tokens}
+                        logger.warning(
+                            "[BEDROCK] Converted adaptive thinking to enabled (budget_tokens=%d, max_tokens=%d) — Bedrock does not support adaptive type",
+                            _budget_tokens, _max_tokens,
+                        )
                     bedrock_body["thinking"] = _thinking_val
                 else:
                     logger.warning(


### PR DESCRIPTION
… conversion

Bedrock requires max_tokens > budget_tokens strictly. The previous fixed value of 8000 equalled the default max_tokens=8000 and triggered a ValidationException. Now budget_tokens = max(1024, max_tokens - 1000), always leaving a 1000-token gap for the non-thinking output.

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/letta-ai/letta/issues) or [PRs](https://github.com/letta-ai/letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
