### PR TITLE
feat: add optional task_id param to /messages for step-wise latency logging 

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -433,15 +433,12 @@ class LettaAgent(BaseAgent):
         self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override)
 
         _ctx_prep_start = get_utc_timestamp_ns() if task_id else None
-        current_in_context_messages, new_in_context_messages = await _prepare_in_context_messages_no_persist_async(
-            input_messages, agent_state, self.message_manager, self.actor
-        )
-        if task_id and _ctx_prep_start:
-            logger.warning(f"[TASK_LATENCY] task_id={task_id} phase=context_prep duration_ms={ns_to_ms(get_utc_timestamp_ns() - _ctx_prep_start)}")
         async with AsyncTimer() as _t:
             current_in_context_messages, new_in_context_messages = await _prepare_in_context_messages_no_persist_async(
                 input_messages, agent_state, self.message_manager, self.actor
             )
+        if task_id and _ctx_prep_start:
+            logger.warning(f"[TASK_LATENCY] task_id={task_id} phase=context_prep duration_ms={ns_to_ms(get_utc_timestamp_ns() - _ctx_prep_start)}")
         _log_step_timing("message_buffer_load", _t.elapsed_ms,
                          agent_id=agent_state.id, user_id=self.at_user_id,
                          msg_count=len(current_in_context_messages))

--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -175,6 +175,7 @@ class LettaAgent(BaseAgent):
         user_cohort: Optional[str] = None,
         thinking: Optional[dict] = None,
         output_config: Optional[dict] = None,
+        task_id: Optional[str] = None,
     ) -> LettaResponse:
         agent_state = await self.agent_manager.get_agent_by_id_async(
             agent_id=self.agent_id, include_relationships=["tools", "memory", "tool_exec_environment_variables"], actor=self.actor
@@ -190,6 +191,7 @@ class LettaAgent(BaseAgent):
             user_cohort=user_cohort,
             thinking=thinking,
             output_config=output_config,
+            task_id=task_id,
         )
         return _create_letta_response(
             new_in_context_messages=new_in_context_messages,
@@ -390,6 +392,7 @@ class LettaAgent(BaseAgent):
         user_cohort: Optional[str] = None,
         thinking: Optional[dict] = None,
         output_config: Optional[dict] = None,
+        task_id: Optional[str] = None,
     ) -> Tuple[List[Message], List[Message], Optional[LettaStopReason], LettaUsageStatistics]:
         """
         Carries out an invocation of the agent loop. In each step, the agent
@@ -403,9 +406,12 @@ class LettaAgent(BaseAgent):
         # Handle provider switching based on experiment flags
         self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override)
 
+        _ctx_prep_start = get_utc_timestamp_ns() if task_id else None
         current_in_context_messages, new_in_context_messages = await _prepare_in_context_messages_no_persist_async(
             input_messages, agent_state, self.message_manager, self.actor
         )
+        if task_id and _ctx_prep_start:
+            logger.warning(f"[TASK_LATENCY] task_id={task_id} phase=context_prep duration_ms={ns_to_ms(get_utc_timestamp_ns() - _ctx_prep_start)}")
         initial_messages = new_in_context_messages
         tool_rules_solver = ToolRulesSolver(agent_state.tool_rules)
         llm_client = LLMClient.create(
@@ -428,6 +434,7 @@ class LettaAgent(BaseAgent):
             agent_step_span = tracer.start_span("agent_step", start_time=step_start)
             agent_step_span.set_attributes({"step_id": step_id})
 
+            _llm_start = get_utc_timestamp_ns() if task_id else None
             request_data, response_data, current_in_context_messages, new_in_context_messages, valid_tool_names = (
                 await self._build_and_request_from_llm(
                     current_in_context_messages, new_in_context_messages, agent_state, llm_client, tool_rules_solver, agent_step_span,
@@ -435,6 +442,8 @@ class LettaAgent(BaseAgent):
                     thinking=thinking, output_config=output_config,
                 )
             )
+            if task_id and _llm_start:
+                logger.warning(f"[TASK_LATENCY] task_id={task_id} step={i} phase=llm_call duration_ms={ns_to_ms(get_utc_timestamp_ns() - _llm_start)}")
             in_context_messages = current_in_context_messages + new_in_context_messages
 
             log_event("agent.step.llm_response.received")  # [3^]
@@ -481,6 +490,7 @@ class LettaAgent(BaseAgent):
                 logger.info("No reasoning content found.")
                 reasoning = None
 
+            _tool_start = get_utc_timestamp_ns() if task_id else None
             persisted_messages, should_continue, stop_reason = await self._handle_ai_response(
                 tool_call,
                 valid_tool_names,
@@ -493,6 +503,8 @@ class LettaAgent(BaseAgent):
                 agent_step_span=agent_step_span,
                 is_final_step=(i == max_steps - 1),
             )
+            if task_id and _tool_start:
+                logger.warning(f"[TASK_LATENCY] task_id={task_id} step={i} phase=tool_exec duration_ms={ns_to_ms(get_utc_timestamp_ns() - _tool_start)}")
             self.response_messages.extend(persisted_messages)
             new_in_context_messages.extend(persisted_messages)
             initial_messages = None
@@ -502,6 +514,8 @@ class LettaAgent(BaseAgent):
             now = get_utc_timestamp_ns()
             step_ns = now - step_start
             agent_step_span.add_event(name="step_ms", attributes={"duration_ms": ns_to_ms(step_ns)})
+            if task_id:
+                logger.warning(f"[TASK_LATENCY] task_id={task_id} step={i} phase=total_step duration_ms={ns_to_ms(step_ns)}")
             agent_step_span.end()
 
             # Log LLM Trace
@@ -528,6 +542,7 @@ class LettaAgent(BaseAgent):
         request_span.end()
 
         # Extend the in context message ids
+        _ctx_rebuild_start = get_utc_timestamp_ns() if task_id else None
         if not agent_state.message_buffer_autoclear:
             await self._rebuild_context_window(
                 in_context_messages=current_in_context_messages,
@@ -536,6 +551,10 @@ class LettaAgent(BaseAgent):
                 total_tokens=usage.total_tokens,
                 force=False,
             )
+        if task_id and _ctx_rebuild_start:
+            logger.warning(f"[TASK_LATENCY] task_id={task_id} phase=ctx_rebuild duration_ms={ns_to_ms(get_utc_timestamp_ns() - _ctx_rebuild_start)}")
+        if task_id and request_start_timestamp_ns:
+            logger.warning(f"[TASK_LATENCY] task_id={task_id} phase=total_request duration_ms={ns_to_ms(get_utc_timestamp_ns() - request_start_timestamp_ns)}")
 
         return current_in_context_messages, new_in_context_messages, usage, stop_reason
 

--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -66,6 +66,11 @@ class LettaRequest(BaseModel):
         description="Output config forwarded to the Claude API (e.g. {'effort': 'high'}).",
     )
 
+    task_id: Optional[str] = Field(
+        default=None,
+        description="Optional task ID for step-wise latency logging. When provided, timing for each phase (context prep, LLM call, tool execution, context rebuild) is emitted as warning logs to help identify bottlenecks.",
+    )
+
 
 class LettaStreamingRequest(LettaRequest):
     stream_tokens: bool = Field(

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -724,6 +724,7 @@ async def send_message(
             user_cohort=request.user_cohort,
             thinking=request.thinking,
             output_config=request.output_config,
+            task_id=request.task_id,
         )
     else:
         result = await server.send_message_to_agent(


### PR DESCRIPTION
## Summary

- Adds an optional `task_id: Optional[str]` field to `LettaRequest` (and its subclasses via inheritance)
- Threads the value through the route handler → `LettaAgent.step()` → `_step()`
- When `task_id` is present, emits `WARNING`-level `[TASK_LATENCY]` log lines at every major phase of `_step()` so bottlenecks in the ~60s latency can be identified by grepping for the task ID

## Phases logged (per-step where applicable)

| Log phase | What it measures |
|---|---|
| `context_prep` | DB fetch + message hydration |
| `llm_call` | Full network round-trip to Claude |
| `tool_exec` | Tool dispatch + message persistence |
| `total_step` | One full agent step |
| `ctx_rebuild` | Post-loop context window trimming |
| `total_request` | End-to-end from HTTP receipt to return |

## Usage

Pass `"task_id": "<any-unique-string>"` in the request body. No behaviour change when absent.