### PR TITLE
feat: add optional task_id param to /messages for step-wise latency logging

### DIFF
--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -1,6 +1,6 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl, field_validator
 
 from letta.constants import DEFAULT_MAX_STEPS, DEFAULT_MESSAGE_TOOL, DEFAULT_MESSAGE_TOOL_KWARG
 from letta.schemas.letta_message import MessageType
@@ -70,6 +70,14 @@ class LettaRequest(BaseModel):
         default=None,
         description="Optional task ID for step-wise latency logging. When provided, timing for each phase (context prep, LLM call, tool execution, context rebuild) is emitted as warning logs to help identify bottlenecks.",
     )
+
+    @field_validator("task_id", mode="before")
+    @classmethod
+    def coerce_task_id_to_str(cls, v: Any) -> Optional[str]:
+        """Accept integers or any scalar as task_id and coerce to string."""
+        if v is None:
+            return None
+        return str(v)
 
 
 class LettaStreamingRequest(LettaRequest):


### PR DESCRIPTION
## Summary

Adds an optional `task_id` field to the `/v1/agents/{agent_id}/messages` request body. When present, the agent loop emits structured `[TASK_LATENCY]` warning logs at every major phase of `_step()` so bottlenecks in the ~60 s latency can be identified by grepping for the task ID.

## What changed

### `letta/schemas/letta_request.py`
- Added `task_id: Optional[str]` field to `LettaRequest` (inherited by `LettaStreamingRequest` and `LettaBatchRequest`)
- Added a `@field_validator("task_id", mode="before")` that coerces any scalar (int, float, etc.) to string — so callers can pass an integer order ID like `289449925` without a `RequestValidationError`

### `letta/server/rest_api/routers/v1/agents.py`
- Passes `task_id=request.task_id` through to `agent_loop.step()`

### `letta/agents/letta_agent.py`
- Added `task_id: Optional[str] = None` to `step()` and `_step()` signatures
- When `task_id` is set, emits `[TASK_LATENCY]` logs at each phase:

| Phase | What it measures |
|---|---|
| `context_prep` | `_prepare_in_context_messages_no_persist_async` — DB fetch + message hydration |
| `llm_call` (per step) | `_build_and_request_from_llm` — full network round-trip to Claude |
| `tool_exec` (per step) | `_handle_ai_response` — tool dispatch + message persistence |
| `total_step` (per step) | One full agent step |
| `ctx_rebuild` | `_rebuild_context_window` — post-loop context trimming |
| `total_request` | End-to-end from HTTP receipt |

## Post-merge fix

After merging `main-custom`, a conflict left `_prepare_in_context_messages_no_persist_async` called twice back-to-back in `_step()` (once from our timing block, once from the upstream `AsyncTimer` block). Fixed by collapsing into a single call wrapped in `AsyncTimer`, preserving both timing mechanisms.

## Usage

Pass any unique identifier as `task_id` in the request body:

```json
{
  "messages": [...],
  "task_id": 289449925
}
```

Logs emitted (grep for `TASK_LATENCY`):
```
[TASK_LATENCY] task_id=289449925 phase=context_prep duration_ms=38
[TASK_LATENCY] task_id=289449925 step=0 phase=llm_call duration_ms=27400
[TASK_LATENCY] task_id=289449925 step=0 phase=tool_exec duration_ms=290
[TASK_LATENCY] task_id=289449925 step=0 phase=total_step duration_ms=27750
[TASK_LATENCY] task_id=289449925 phase=ctx_rebuild duration_ms=48
[TASK_LATENCY] task_id=289449925 phase=total_request duration_ms=27900
```

**No behaviour change when `task_id` is absent** — all timing guards are `if task_id` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)