### PR TITLE
fix(anthropic_client): handle tool_use.input as JSON-string in respon…

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -1186,7 +1186,29 @@ class AnthropicClient(LLMClientBase):
                 if content_part.type == "tool_use":
                     # hack for incorrect tool format
                     tool_input = json.loads(json.dumps(content_part.input))
-                    if "id" in tool_input and tool_input["id"].startswith("toolu_") and "function" in tool_input:
+
+                    # Defensive: some model/provider combinations (notably Haiku on Bedrock
+                    # with restricted tool_choice) return `input` as a JSON-encoded string
+                    # instead of a dict. The "id" in tool_input check below would then do
+                    # a substring scan on the string and the subsequent tool_input["id"]
+                    # access would raise TypeError("string indices must be integers, not 'str'").
+                    # Parse string-shaped inputs back to a dict before the format hack runs.
+                    if isinstance(tool_input, str):
+                        logger.warning(
+                            "[ANTHROPIC_CLIENT] tool_use.input arrived as a string (len=%d, name=%s); parsing as JSON",
+                            len(tool_input),
+                            getattr(content_part, "name", "?"),
+                        )
+                        try:
+                            _parsed = json.loads(tool_input)
+                            if isinstance(_parsed, dict):
+                                tool_input = _parsed
+                        except (ValueError, TypeError):
+                            # Leave as string; the isinstance(dict) guard below will skip
+                            # the OpenAI-style nested-format branch and fall through.
+                            pass
+
+                    if isinstance(tool_input, dict) and "id" in tool_input and tool_input["id"].startswith("toolu_") and "function" in tool_input:
                         arguments = json.dumps(tool_input["function"]["arguments"], indent=2)
                         try:
                             args_json = json.loads(arguments)


### PR DESCRIPTION
…se parsing

Haiku 4.5 on Bedrock (and likely other model/provider combinations) returns the `input` field of tool_use content blocks as a JSON-encoded STRING rather than a dict. The existing "hack for incorrect tool format" branch then runs `"id" in tool_input` — which does substring matching on a string and can spuriously return True — followed by `tool_input["id"]`, which raises TypeError: "string indices must be integers, not 'str'".

This was the source of the 500s we saw when latencyOptimisationFlow=true routed Haiku tool calls through Bedrock. The error was caught by the global OTEL exception handler and recorded only on a span, leaving no traceback in Loki, which is what made the bug hard to find.

Fix:
  - If `tool_input` is a string, attempt to json.loads it; if the parse succeeds and yields a dict, swap it in.
  - Guard the OpenAI-nested-format branch with `isinstance(tool_input, dict)` so a non-dict can never reach the string-indexing line.
  - Log a WARNING with the tool name and string length when the string-shaped input is observed, so we have visibility on which models produce this format.

No behaviour change for response shapes that already returned a dict (the common case for Sonnet, Opus, Vertex).

