### PR TITLE
fix(otel): log full 5xx tracebacks to Loki via the global exception handler

### DIFF
--- a/letta/otel/tracing.py
+++ b/letta/otel/tracing.py
@@ -114,6 +114,19 @@ async def _trace_error_handler(_request: Request, exc: Exception) -> JSONRespons
             },
         )
 
+    # Also write the full traceback to the regular logger so it shows up in Loki
+    # (span events alone are easy to miss and require digging through the tracing
+    # backend). Only log 5xx errors with traceback; 4xx are usually expected.
+    if status_code >= 500:
+        logger.error(
+            "[UNHANDLED_EXCEPTION] %s: %s (path=%s method=%s)",
+            type(exc).__name__,
+            error_msg,
+            getattr(_request, "url", "?"),
+            getattr(_request, "method", "?"),
+            exc_info=exc,
+        )
+
     return JSONResponse(status_code=status_code, content={"detail": error_msg, "trace_id": get_trace_id() or ""})
 
 


### PR DESCRIPTION
## Why

The global OpenTelemetry exception handler at `letta/otel/tracing.py::_trace_error_handler` records exceptions ONLY as span events. That means whenever any route raises an unhandled exception, the 500 response contains the error string but the **Python traceback never reaches Loki** — it lives only on a tracing span you have to dig into Jaeger / Tempo / Grafana Traces to find.

This bit us during a recent debug session — a `TypeError: string indices must be integers, not 'str'` was 500ing in the Haiku cascade path and we had absolutely no way to find out which file/line it originated from. The DBG logs we had to add were a workaround. With this change, the next 500 surfaces its full stack trace as a single `[UNHANDLED_EXCEPTION]` log line in Loki.

## Change

In `_trace_error_handler`, for any `status_code >= 500`, also call `logger.error("[UNHANDLED_EXCEPTION] ...", exc_info=exc)`. The `exc_info` argument makes Python emit the full formatted traceback as part of the log record.

- 4xx errors are intentionally **not** logged this way — they are usually expected validation failures and would just add noise.
- Span event recording is preserved unchanged, so tracing backends still get the same data.
- No behaviour change in the response body (`{"detail": ..., "trace_id": ...}` shape is the same).

## How to verify

After deploy, trigger any 500 (or wait for one to happen organically). In Loki:

```logql
{job="letta-server"} |= "UNHANDLED_EXCEPTION"
```

You should see exactly one entry per failed request, containing:
- Exception type and message
- Request path and method
- Full Python stack trace down to the line that raised

## Diff

+13 / -0 lines. Pure observability improvement; no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)