### PR TITLE
fix(anthropic_client): guard nested tool_use.input format against non-dict function

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -1208,15 +1208,32 @@ class AnthropicClient(LLMClientBase):
                             # the OpenAI-style nested-format branch and fall through.
                             pass
 
-                    if isinstance(tool_input, dict) and "id" in tool_input and tool_input["id"].startswith("toolu_") and "function" in tool_input:
-                        arguments = json.dumps(tool_input["function"]["arguments"], indent=2)
+                    # Detect the OpenAI-style nested format some models return:
+                    #   {"id": "toolu_...", "function": {"name": "...", "arguments": {...}}}
+                    # Each access must be guarded — at least one observed Haiku 4.5
+                    # response on Bedrock returned `function` as a STRING instead of a
+                    # dict, which crashed `tool_input["function"]["arguments"]` with
+                    # TypeError: string indices must be integers. We now require
+                    # `function` to be a dict before stepping into it.
+                    _is_nested_openai_format = (
+                        isinstance(tool_input, dict)
+                        and isinstance(tool_input.get("id"), str)
+                        and tool_input["id"].startswith("toolu_")
+                        and isinstance(tool_input.get("function"), dict)
+                    )
+                    if _is_nested_openai_format:
+                        _function_dict = tool_input["function"]
+                        _args_raw = _function_dict.get("arguments")
+                        arguments = json.dumps(_args_raw, indent=2)
                         try:
                             args_json = json.loads(arguments)
                             if not isinstance(args_json, dict):
                                 raise ValueError("Expected parseable json object for arguments")
                         except:
-                            arguments = str(tool_input["function"]["arguments"])
+                            arguments = str(_args_raw)
                     else:
+                        # Standard Anthropic format: `input` IS the arguments dict
+                        # (or whatever else the model returned — we serialize it as-is).
                         arguments = json.dumps(tool_input, indent=2)
                     tool_calls = [
                         ToolCall(


### PR DESCRIPTION
## The bug (with full traceback)

```
File "/app/letta/llm_api/anthropic_client.py", line 1212, in convert_response_to_chat_completion
    arguments = json.dumps(tool_input["function"]["arguments"], indent=2)
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```

Observed on Haiku 4.5 on Bedrock with `latencyOptimisationFlow=true`.

## What was happening

The "hack for incorrect tool format" branch in `convert_response_to_chat_completion` handles a non-standard OpenAI-style nested shape some models return for `tool_use.input`:

```json
{"id": "toolu_...", "function": {"name": "...", "arguments": {...}}}
```

The condition guarded the outer access (`isinstance(tool_input, dict)`, `"function" in tool_input`) but assumed `tool_input["function"]` was itself a dict.

Haiku 4.5 on Bedrock returned a response where the top-level dict matched the shape **AND** `function` was a STRING — so the inner `["arguments"]` indexed a string and the request 500ed.

## Fix

Bundle all four conditions into a single `_is_nested_openai_format` predicate that also requires `isinstance(tool_input.get("function"), dict)`. When `function` is anything other than a dict, fall through to the standard branch (treat `tool_input` as the arguments dict directly).

Also uses a typed local `_args_raw` so the fallback `str(...)` path can't index through string-shaped `function` either.

## Backwards compatibility

- Sonnet, Opus, and Vertex paths return `function` as a dict → no change in behaviour.
- Models that return the standard `tool_use.input` shape (just the arguments dict) → no change.
- The only behavioural difference is for the edge case that was crashing: instead of TypeError, we now correctly handle it.

## How to verify

After deploy, retry a request that previously 500ed with `latencyOptimisationFlow: true`. Expected: HTTP 200 with the agent's response, and `[HAIKU_CASCADE] step=N USAGE used_haiku=True tool=...` logs showing Haiku tool calls succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)