### PR TITLE
fix(anthropic_client): also parse JSON-string `function` and `argumen…

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -1210,20 +1210,46 @@ class AnthropicClient(LLMClientBase):
 
                     # Detect the OpenAI-style nested format some models return:
                     #   {"id": "toolu_...", "function": {"name": "...", "arguments": {...}}}
-                    # Each access must be guarded — at least one observed Haiku 4.5
-                    # response on Bedrock returned `function` as a STRING instead of a
-                    # dict, which crashed `tool_input["function"]["arguments"]` with
-                    # TypeError: string indices must be integers. We now require
-                    # `function` to be a dict before stepping into it.
-                    _is_nested_openai_format = (
+                    # and the variant Haiku 4.5 on Bedrock has been observed to return,
+                    # where `function` itself is a JSON-encoded STRING:
+                    #   {"id": "toolu_...", "function": "{\"name\":\"...\",\"arguments\":{...}}"}
+                    # Both variants ultimately want us to extract function["arguments"]
+                    # as the real tool arguments dict. Without this normalisation a
+                    # send_message call would lose its `message` key and downstream
+                    # validators would raise "Function call ... missing ... argument".
+                    _function = None
+                    _is_nested_openai_format = False
+                    if (
                         isinstance(tool_input, dict)
                         and isinstance(tool_input.get("id"), str)
                         and tool_input["id"].startswith("toolu_")
-                        and isinstance(tool_input.get("function"), dict)
-                    )
+                        and "function" in tool_input
+                    ):
+                        _function = tool_input["function"]
+                        if isinstance(_function, str):
+                            # Provider returned function as a JSON string — parse it.
+                            try:
+                                _parsed_function = json.loads(_function)
+                                if isinstance(_parsed_function, dict):
+                                    _function = _parsed_function
+                                else:
+                                    _function = None
+                            except (ValueError, TypeError):
+                                _function = None
+                        if isinstance(_function, dict):
+                            _is_nested_openai_format = True
+
                     if _is_nested_openai_format:
-                        _function_dict = tool_input["function"]
-                        _args_raw = _function_dict.get("arguments")
+                        _args_raw = _function.get("arguments")
+                        # The `arguments` field itself may also be a JSON-encoded string
+                        # in some response shapes — normalise to a dict if so.
+                        if isinstance(_args_raw, str):
+                            try:
+                                _parsed_args = json.loads(_args_raw)
+                                if isinstance(_parsed_args, dict):
+                                    _args_raw = _parsed_args
+                            except (ValueError, TypeError):
+                                pass
                         arguments = json.dumps(_args_raw, indent=2)
                         try:
                             args_json = json.loads(arguments)


### PR DESCRIPTION
…ts` in nested tool_use.input

After PR #105 (which guarded `function` against non-dict), production still returned HTTP 400 with "Function call send_message missing message argument". Root cause: Haiku 4.5 on Bedrock returns the nested OpenAI format with `function` itself as a JSON-encoded STRING, e.g.:

    {"id": "toolu_xxx",
     "function": "{\"name\":\"send_message\",\"arguments\":{\"message\":\"hi\"}}"}

PR #105's `isinstance(function, dict)` check correctly rejected the string and fell through to the standard branch — but that branch serialises the WHOLE input dict as the tool arguments, so the resulting arguments string becomes `{"id": ..., "function": ...}` and downstream code finds no `message` key.

This commit completes the normalisation:

  1. When `function` is a string, attempt to json.loads it; if the result is a dict, swap it in so the nested-format branch fires.
  2. When `function["arguments"]` is itself a string (also observed in some response shapes), attempt to json.loads that into a dict.

End result: all five observed `tool_use.input` shapes produce the same correct arguments JSON string:

  - {"message": "hi"}                                            (standard)
  - "{\"message\": \"hi\"}"                                      (input as JSON string — handled by earlier patch)
  - {"id": ..., "function": {"name": ..., "arguments": {...}}}   (function as dict)
  - {"id": ..., "function": "{\"name\": ..., \"arguments\": {...}}"} (function as JSON string)
  - {"id": ..., "function": {..., "arguments": "{...}"}}         (arguments as JSON string)

No change for Sonnet/Opus standard responses — they continue to use the `else` branch that serialises `tool_input` directly as the args dict.

**Please describe the purpose of this pull request.**
Is it to add a new feature? Is it to fix a bug?

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/letta-ai/letta/issues) or [PRs](https://github.com/letta-ai/letta/pulls).

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.

**Additional context**
Add any other context or screenshots about the PR here.
