### PR TITLE
feat(haiku-cascade): publish end-to-end + per-step latency metrics

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -564,6 +564,7 @@ class LettaAgent(BaseAgent):
 
             _original_model: Optional[str] = None
             _step_used_haiku: bool = False
+            _step_was_retried: bool = False  # flipped to True if the gate forces a primary retry
             if _haiku_model and i > 0:
                 _original_model = agent_state.llm_config.model
                 agent_state.llm_config.model = _haiku_model
@@ -660,6 +661,7 @@ class LettaAgent(BaseAgent):
                     MetricRegistry().haiku_cascade_wasted_tokens_histogram.record(
                         response.usage.total_tokens, _retry_attrs
                     )
+                    _step_was_retried = True
 
                     # Re-run on the primary model with the full tool list (no exclusions).
                     # The model is already restored above; the pre-call message snapshot avoids
@@ -783,6 +785,24 @@ class LettaAgent(BaseAgent):
             agent_step_span.add_event(name="step_ms", attributes={"duration_ms": ns_to_ms(step_ns)})
             if task_id:
                 logger.warning(f"[TASK_LATENCY] task_id={task_id} step={i} phase=total_step duration_ms={ns_to_ms(step_ns)}")
+
+            # OTel: per-step latency tagged with cascade outcome. Lets us answer
+            # "how long do Haiku-kept steps take vs primary-retried steps?".
+            if latency_optimisation_flow:
+                if _step_used_haiku:
+                    _step_outcome = "haiku_kept"
+                elif _step_was_retried:
+                    _step_outcome = "primary_retried"
+                elif _haiku_model and i == 0:
+                    _step_outcome = "primary_step0"
+                elif not _haiku_model:
+                    _step_outcome = "primary_no_haiku_model"
+                else:
+                    _step_outcome = "primary_kept"
+                MetricRegistry().haiku_cascade_step_ms_histogram.record(
+                    ns_to_ms(step_ns), _cascade_attrs(outcome=_step_outcome)
+                )
+
             agent_step_span.end()
 
             # Log LLM Trace
@@ -849,12 +869,34 @@ class LettaAgent(BaseAgent):
 
             # OTel: per-request histograms so the cascade is observable in Grafana
             # without scraping log lines. `had_retry` lets the request counter slice
-            # be partitioned by whether a retry fired.
-            _summary_attrs = _cascade_attrs(had_retry=str(_haiku_retried_step_count > 0).lower())
+            # be partitioned by whether a retry fired. `total_steps_bucket` bins
+            # the step count so dashboards can split p50/p95 latency by workload
+            # shape without needing a heatmap.
+            def _bucket(n: int) -> str:
+                if n <= 1:
+                    return "1"
+                if n == 2:
+                    return "2"
+                if n <= 5:
+                    return "3-5"
+                return "6+"
+
+            _summary_attrs = _cascade_attrs(
+                had_retry=str(_haiku_retried_step_count > 0).lower(),
+                total_steps_bucket=_bucket(_total_steps),
+            )
             MetricRegistry().haiku_cascade_total_steps_histogram.record(_total_steps, _summary_attrs)
             MetricRegistry().haiku_cascade_haiku_pct_histogram.record(_haiku_step_pct, _summary_attrs)
             MetricRegistry().haiku_cascade_haiku_tokens_histogram.record(_haiku_total_tokens, _summary_attrs)
             MetricRegistry().haiku_cascade_primary_tokens_histogram.record(_primary_total_tokens, _summary_attrs)
+
+            # The headline cascade metric: total end-to-end latency for cascade-enabled
+            # requests, partitioned by had_retry and total_steps_bucket. Use this to
+            # prove "the cascade made things faster" by comparing percentiles vs the
+            # same time window before the cascade went live.
+            if request_start_timestamp_ns:
+                _request_ms = ns_to_ms(get_utc_timestamp_ns() - request_start_timestamp_ns)
+                MetricRegistry().haiku_cascade_request_ms_histogram.record(_request_ms, _summary_attrs)
 
         return current_in_context_messages, new_in_context_messages, usage, stop_reason
 

--- a/letta/otel/metric_registry.py
+++ b/letta/otel/metric_registry.py
@@ -255,3 +255,35 @@ class MetricRegistry:
                 unit="1",
             ),
         )
+
+    # Per-request total latency in ms — this is the headline cascade metric.
+    # Compare percentiles vs non-cascade traffic to quantify the latency win.
+    # Attributes include `had_retry` so we can split "ideal path" vs "retry path"
+    # and `total_steps_bucket` (1 | 2 | 3-5 | 6+) so the multi-step economics
+    # are visible at a glance without needing the histogram heatmap.
+    @property
+    def haiku_cascade_request_ms_histogram(self) -> Histogram:
+        return self._get_or_create_metric(
+            "hist_haiku_cascade_request_ms",
+            partial(
+                self._meter.create_histogram,
+                name="hist_haiku_cascade_request_ms",
+                description="End-to-end request latency (ms) when the Haiku cascade is enabled.",
+                unit="ms",
+            ),
+        )
+
+    # Per-step latency in ms, tagged with outcome so we can see e.g. "Haiku kept
+    # steps average X ms, primary retried steps average Y ms". Complements the
+    # existing hist_step_execution_time_ms (which has no cascade-outcome label).
+    @property
+    def haiku_cascade_step_ms_histogram(self) -> Histogram:
+        return self._get_or_create_metric(
+            "hist_haiku_cascade_step_ms",
+            partial(
+                self._meter.create_histogram,
+                name="hist_haiku_cascade_step_ms",
+                description="Per-step latency (ms) when the Haiku cascade is enabled, partitioned by outcome.",
+                unit="ms",
+            ),
+        )


### PR DESCRIPTION
The headline question for the cascade is "did it make things faster". Adding two latency histograms so we can answer that from Grafana without scraping `[TASK_LATENCY] phase=total_request` log lines.

New metrics in MetricRegistry:

  hist_haiku_cascade_request_ms — end-to-end request latency (ms) when
      the cascade is enabled. Recorded once per request at SUMMARY time
      using request_start_timestamp_ns. Attributes include `had_retry`
      and a `total_steps_bucket` (1 | 2 | 3-5 | 6+) so dashboards can
      split percentiles by workload shape without a heatmap.

  hist_haiku_cascade_step_ms — per-step latency (ms) partitioned by the
      cascade outcome attribute (`haiku_kept`, `primary_step0`,
      `primary_retried`, `primary_no_haiku_model`, `primary_kept`). Lets
      us answer "how long does a Haiku step take vs a primary-retried
      step" directly.

Implementation:

  - Added `_step_was_retried` boolean tracker inside the step loop and set it where the gate fires, so the per-step latency tag is computed explicitly rather than reverse-engineered from counters.
  - The summary block now records the request latency only when `request_start_timestamp_ns` is set (which it always is for the /messages endpoint).
  - `total_steps_bucket` attribute is shared between the request_ms histogram and the existing per-request histograms so the same slice is available across all of them.

Once deployed, percentile dashboards land out of the box:

  histogram_quantile(0.95, sum by(le, total_steps_bucket) (
      rate(hist_haiku_cascade_request_ms_bucket[5m])))