### PR TITLE
feat(metrics): per-flow E2E latency for /messages (latencyOptimisationFlow)

### DIFF
--- a/letta/otel/metric_registry.py
+++ b/letta/otel/metric_registry.py
@@ -159,6 +159,27 @@ class MetricRegistry:
             ),
         )
 
+    # Headline metric for comparing the two /messages flows. Recorded inside the
+    # send_message route handler (NOT the ASGI middleware) because the
+    # latencyOptimisationFlow flag lives in the request body and is only known
+    # there — the middleware runs the handler in a separate task, so a context
+    # attribute set in the handler never propagates back up to it.
+    # Attributes (all low cardinality):
+    #   - latency_optimisation_flow : "true" | "false"
+    #   - status_code               : HTTP status of the response
+    #   plus the base ctx attributes (organization.id, project.id, agent.id, ...)
+    @property
+    def messages_endpoint_e2e_ms_histogram(self) -> Histogram:
+        return self._get_or_create_metric(
+            "hist_messages_endpoint_e2e_ms",
+            partial(
+                self._meter.create_histogram,
+                name="hist_messages_endpoint_e2e_ms",
+                description="End-to-end latency (ms) of POST /v1/agents/{id}/messages, partitioned by latency_optimisation_flow.",
+                unit="ms",
+            ),
+        )
+
     # --- Haiku cascade (latencyOptimisationFlow) metrics ---
     # All attributes use low cardinality:
     #   - provider  : anthropic | anthropic_vertex | anthropic_bedrock

--- a/letta/otel/metrics.py
+++ b/letta/otel/metrics.py
@@ -102,32 +102,63 @@ def _record_endpoint_metrics(
 
 
 def setup_metrics(
-    endpoint: str,
+    endpoint: str | None = None,
     app: FastAPI | None = None,
     service_name: str = "memgpt-server",
+    prometheus_enabled: bool = False,
 ) -> None:
+    """Initialise the metrics pipeline.
+
+    Two independent readers may be attached to the MeterProvider:
+      - OTLP push exporter (when `endpoint` is set) — ships metrics to a collector.
+      - Prometheus pull reader (when `prometheus_enabled`) — exposes a /metrics
+        scrape endpoint on `app`. Cumulative temporality is forced by the reader,
+        as Prometheus requires; this is independent of otel_preferred_temporality.
+
+    At least one of `endpoint` / `prometheus_enabled` must be provided, otherwise
+    metrics stay uninitialised (and all MetricRegistry instruments are no-ops).
+    """
     if is_pytest_environment():
         return
-    assert endpoint
+
+    metric_readers = []
+
+    if endpoint:
+        preferred_temporality = AggregationTemporality(settings.otel_preferred_temporality)
+        otlp_metric_exporter = OTLPMetricExporter(
+            endpoint=endpoint,
+            preferred_temporality={
+                # Add more as needed here.
+                Counter: preferred_temporality,
+                Histogram: preferred_temporality,
+            },
+        )
+        metric_readers.append(PeriodicExportingMetricReader(exporter=otlp_metric_exporter))
+
+    if prometheus_enabled:
+        # Registers a collector into the default prometheus_client REGISTRY; the
+        # /metrics ASGI app mounted below serves that same registry.
+        from opentelemetry.exporter.prometheus import PrometheusMetricReader
+
+        metric_readers.append(PrometheusMetricReader())
+
+    if not metric_readers:
+        logger.warning("setup_metrics called with no exporter configured (no OTLP endpoint, Prometheus disabled); skipping.")
+        return
 
     global _is_metrics_initialized, _meter
-    preferred_temporality = AggregationTemporality(settings.otel_preferred_temporality)
-    otlp_metric_exporter = OTLPMetricExporter(
-        endpoint=endpoint,
-        preferred_temporality={
-            # Add more as needed here.
-            Counter: preferred_temporality,
-            Histogram: preferred_temporality,
-        },
-    )
-    metric_reader = PeriodicExportingMetricReader(exporter=otlp_metric_exporter)
-
-    meter_provider = MeterProvider(resource=get_resource(service_name), metric_readers=[metric_reader])
+    meter_provider = MeterProvider(resource=get_resource(service_name), metric_readers=metric_readers)
     metrics.set_meter_provider(meter_provider)
     _meter = metrics.get_meter(__name__)
 
     if app:
         app.middleware("http")(_otel_metric_middleware)
+        if prometheus_enabled:
+            from prometheus_client import make_asgi_app
+
+            # Private scrape endpoint — restrict access at the infra/network layer.
+            app.mount("/metrics", make_asgi_app())
+            logger.info("Prometheus metrics scrape endpoint mounted at /metrics")
 
     _is_metrics_initialized = True
 

--- a/letta/otel/metrics.py
+++ b/letta/otel/metrics.py
@@ -111,9 +111,11 @@ def setup_metrics(
 
     Two independent readers may be attached to the MeterProvider:
       - OTLP push exporter (when `endpoint` is set) — ships metrics to a collector.
-      - Prometheus pull reader (when `prometheus_enabled`) — exposes a /metrics
-        scrape endpoint on `app`. Cumulative temporality is forced by the reader,
-        as Prometheus requires; this is independent of otel_preferred_temporality.
+      - Prometheus pull reader (when `prometheus_enabled`) — serves /metrics from a
+        standalone HTTP server on its OWN dedicated port (settings.otel_metrics_prometheus_port),
+        NOT the API port, so infra can firewall it independently of public traffic.
+        Cumulative temporality is forced by the reader, as Prometheus requires;
+        this is independent of otel_preferred_temporality.
 
     At least one of `endpoint` / `prometheus_enabled` must be provided, otherwise
     metrics stay uninitialised (and all MetricRegistry instruments are no-ops).
@@ -153,12 +155,27 @@ def setup_metrics(
 
     if app:
         app.middleware("http")(_otel_metric_middleware)
-        if prometheus_enabled:
-            from prometheus_client import make_asgi_app
 
-            # Private scrape endpoint — restrict access at the infra/network layer.
-            app.mount("/metrics", make_asgi_app())
-            logger.info("Prometheus metrics scrape endpoint mounted at /metrics")
+    if prometheus_enabled:
+        # Standalone scrape server on a dedicated port (separate from the API port) so
+        # infra can firewall it off from public traffic. Serves the default prometheus
+        # REGISTRY that PrometheusMetricReader populates. Unauthenticated by design —
+        # restrict reachability at the network layer.
+        from prometheus_client import start_http_server
+
+        prom_port = settings.otel_metrics_prometheus_port
+        prom_addr = settings.otel_metrics_prometheus_addr
+        try:
+            start_http_server(port=prom_port, addr=prom_addr)
+            logger.info(f"Prometheus metrics scrape server listening on {prom_addr}:{prom_port} (path /metrics)")
+        except OSError as e:
+            # With uvicorn_workers > 1, each worker process tries to bind the same port;
+            # only the first succeeds. Don't crash the worker — log and continue. (Full
+            # multi-worker coverage needs prometheus_client multiprocess mode.)
+            logger.warning(
+                f"Could not bind Prometheus metrics server on {prom_addr}:{prom_port}: {e}. "
+                "This is expected when uvicorn_workers > 1; metrics for this worker won't be scrapeable."
+            )
 
     _is_metrics_initialized = True
 

--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -253,12 +253,13 @@ def create_application() -> "FastAPI":
 
     # Set up OpenTelemetry tracing
     otlp_endpoint = settings.otel_exporter_otlp_endpoint
-    if otlp_endpoint and not settings.disable_tracing:
+    tracing_enabled = bool(otlp_endpoint) and not settings.disable_tracing
+    env_name_suffix = os.getenv("ENV_NAME")
+    service_name = f"letta-server-{env_name_suffix.lower()}" if env_name_suffix else "letta-server"
+
+    if tracing_enabled:
         print(f"▶ Using OTLP tracing with endpoint: {otlp_endpoint}")
-        env_name_suffix = os.getenv("ENV_NAME")
-        service_name = f"letta-server-{env_name_suffix.lower()}" if env_name_suffix else "letta-server"
         from letta.otel.logging import setup_logging
-        from letta.otel.metrics import setup_metrics
         from letta.otel.tracing import setup_tracing
 
         setup_tracing(
@@ -266,8 +267,21 @@ def create_application() -> "FastAPI":
             app=app,
             service_name=service_name,
         )
-        setup_metrics(endpoint=otlp_endpoint, app=app, service_name=service_name)
         setup_logging(endpoint=otlp_endpoint, service_name=service_name)
+
+    # Metrics init independently of tracing: enabled by an OTLP push endpoint and/or a
+    # Prometheus scrape endpoint. This lets us expose /metrics without running a collector.
+    if tracing_enabled or settings.otel_metrics_prometheus_enabled:
+        from letta.otel.metrics import setup_metrics
+
+        if settings.otel_metrics_prometheus_enabled:
+            print("▶ Exposing Prometheus metrics at /metrics")
+        setup_metrics(
+            endpoint=otlp_endpoint if tracing_enabled else None,
+            app=app,
+            service_name=service_name,
+            prometheus_enabled=settings.otel_metrics_prometheus_enabled,
+        )
 
     for route in v1_routes:
         app.include_router(route, prefix=API_PREFIX)

--- a/letta/server/rest_api/app.py
+++ b/letta/server/rest_api/app.py
@@ -275,7 +275,7 @@ def create_application() -> "FastAPI":
         from letta.otel.metrics import setup_metrics
 
         if settings.otel_metrics_prometheus_enabled:
-            print("▶ Exposing Prometheus metrics at /metrics")
+            print(f"▶ Exposing Prometheus metrics on dedicated port {settings.otel_metrics_prometheus_port} (path /metrics)")
         setup_metrics(
             endpoint=otlp_endpoint if tracing_enabled else None,
             app=app,

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -14,10 +14,10 @@ from starlette.responses import Response, StreamingResponse
 from letta.agents.letta_agent import LettaAgent
 from letta.constants import DEFAULT_MAX_STEPS, DEFAULT_MESSAGE_TOOL, DEFAULT_MESSAGE_TOOL_KWARG
 from letta.groups.sleeptime_multi_agent_v2 import SleeptimeMultiAgentV2
-from letta.helpers.datetime_helpers import get_utc_timestamp_ns
+from letta.helpers.datetime_helpers import get_utc_timestamp_ns, ns_to_ms
 from letta.log import get_logger
 from letta.orm.errors import NoResultFound
-from letta.otel.context import get_ctx_attributes
+from letta.otel.context import add_ctx_attribute, get_ctx_attributes
 from letta.otel.metric_registry import MetricRegistry
 from letta.schemas.agent import AgentState, AgentType, CreateAgent, UpdateAgent
 from letta.schemas.block import Block, BlockUpdate
@@ -677,74 +677,97 @@ async def send_message(
     request_start_timestamp_ns = get_utc_timestamp_ns()
     MetricRegistry().user_message_counter.add(1, get_ctx_attributes())
 
+    # Tag the OTel request context with the flow flag so it propagates DOWN into
+    # the agent loop and labels every nested metric (step / llm / ttft / tokens /
+    # cost) by flow. This lets the obs dashboard slice the existing histograms by
+    # latency_optimisation_flow without any new metrics. Stored as a string so the
+    # two flows render as discrete series ("true" / "false") in group-by queries.
+    _lof_attr = str(bool(request.latencyOptimisationFlow)).lower()
+    add_ctx_attribute("latency_optimisation_flow", _lof_attr)
+
     logger.warning(f"[SEND_MESSAGE] use_vertex_experiment={request.use_vertex_experiment}, use_bedrock_experiment={request.use_bedrock_experiment}, model_override={request.model_override}")
 
+    # Headline end-to-end latency for the two flows, recorded here (not the ASGI
+    # middleware) because the flag is only known inside the handler.
+    status_code = 200
+    try:
+        actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
+        # TODO: This is redundant, remove soon
+        agent = await server.agent_manager.get_agent_by_id_async(agent_id, actor, include_relationships=["multi_agent_group"])
+        agent_eligible = agent.multi_agent_group is None or agent.multi_agent_group.manager_type in ["sleeptime", "voice_sleeptime"]
+        model_compatible = agent.llm_config.model_endpoint_type in ["anthropic", "openai", "together", "google_ai", "google_vertex"]
 
-    actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
-    # TODO: This is redundant, remove soon
-    agent = await server.agent_manager.get_agent_by_id_async(agent_id, actor, include_relationships=["multi_agent_group"])
-    agent_eligible = agent.multi_agent_group is None or agent.multi_agent_group.manager_type in ["sleeptime", "voice_sleeptime"]
-    model_compatible = agent.llm_config.model_endpoint_type in ["anthropic", "openai", "together", "google_ai", "google_vertex"]
+        if agent_eligible and model_compatible:
+            if agent.enable_sleeptime and agent.agent_type != AgentType.voice_convo_agent:
+                agent_loop = SleeptimeMultiAgentV2(
+                    agent_id=agent_id,
+                    message_manager=server.message_manager,
+                    agent_manager=server.agent_manager,
+                    block_manager=server.block_manager,
+                    passage_manager=server.passage_manager,
+                    group_manager=server.group_manager,
+                    job_manager=server.job_manager,
+                    actor=actor,
+                    group=agent.multi_agent_group,
+                )
+            else:
+                agent_loop = LettaAgent(
+                    agent_id=agent_id,
+                    message_manager=server.message_manager,
+                    agent_manager=server.agent_manager,
+                    block_manager=server.block_manager,
+                    passage_manager=server.passage_manager,
+                    actor=actor,
+                    step_manager=server.step_manager,
+                    telemetry_manager=server.telemetry_manager if settings.llm_api_logging else NoopTelemetryManager(),
+                    at_user_id=at_user_id,
+                )
 
-    if agent_eligible and model_compatible:
-        if agent.enable_sleeptime and agent.agent_type != AgentType.voice_convo_agent:
-            agent_loop = SleeptimeMultiAgentV2(
-                agent_id=agent_id,
-                message_manager=server.message_manager,
-                agent_manager=server.agent_manager,
-                block_manager=server.block_manager,
-                passage_manager=server.passage_manager,
-                group_manager=server.group_manager,
-                job_manager=server.job_manager,
-                actor=actor,
-                group=agent.multi_agent_group,
+            result = await agent_loop.step(
+                request.messages,
+                max_steps=request.max_steps,
+                use_assistant_message=request.use_assistant_message,
+                request_start_timestamp_ns=request_start_timestamp_ns,
+                include_return_message_types=request.include_return_message_types,
+                use_vertex_experiment=request.use_vertex_experiment,
+                use_bedrock_experiment=request.use_bedrock_experiment,
+                model_override=request.model_override,
+                user_cohort=request.user_cohort,
+                thinking=request.thinking,
+                output_config=request.output_config,
+                task_id=request.task_id,
+                latency_optimisation_flow=request.latencyOptimisationFlow,
             )
         else:
-            agent_loop = LettaAgent(
+            result = await server.send_message_to_agent(
                 agent_id=agent_id,
-                message_manager=server.message_manager,
-                agent_manager=server.agent_manager,
-                block_manager=server.block_manager,
-                passage_manager=server.passage_manager,
                 actor=actor,
-                step_manager=server.step_manager,
-                telemetry_manager=server.telemetry_manager if settings.llm_api_logging else NoopTelemetryManager(),
-                at_user_id=at_user_id,
+                input_messages=request.messages,
+                stream_steps=False,
+                stream_tokens=False,
+                # Support for AssistantMessage
+                use_assistant_message=request.use_assistant_message,
+                assistant_message_tool_name=request.assistant_message_tool_name,
+                assistant_message_tool_kwarg=request.assistant_message_tool_kwarg,
+                include_return_message_types=request.include_return_message_types,
+                use_vertex_experiment=request.use_vertex_experiment,
+                use_bedrock_experiment=request.use_bedrock_experiment,
+                model_override=request.model_override,
+                user_cohort=request.user_cohort,
             )
-
-        result = await agent_loop.step(
-            request.messages,
-            max_steps=request.max_steps,
-            use_assistant_message=request.use_assistant_message,
-            request_start_timestamp_ns=request_start_timestamp_ns,
-            include_return_message_types=request.include_return_message_types,
-            use_vertex_experiment=request.use_vertex_experiment,
-            use_bedrock_experiment=request.use_bedrock_experiment,
-            model_override=request.model_override,
-            user_cohort=request.user_cohort,
-            thinking=request.thinking,
-            output_config=request.output_config,
-            task_id=request.task_id,
-            latency_optimisation_flow=request.latencyOptimisationFlow,
-        )
-    else:
-        result = await server.send_message_to_agent(
-            agent_id=agent_id,
-            actor=actor,
-            input_messages=request.messages,
-            stream_steps=False,
-            stream_tokens=False,
-            # Support for AssistantMessage
-            use_assistant_message=request.use_assistant_message,
-            assistant_message_tool_name=request.assistant_message_tool_name,
-            assistant_message_tool_kwarg=request.assistant_message_tool_kwarg,
-            include_return_message_types=request.include_return_message_types,
-            use_vertex_experiment=request.use_vertex_experiment,
-            use_bedrock_experiment=request.use_bedrock_experiment,
-            model_override=request.model_override,
-            user_cohort=request.user_cohort,
-        )
-    return result
+        return result
+    except Exception as e:
+        status_code = getattr(e, "status_code", 500)
+        raise
+    finally:
+        e2e_ms = ns_to_ms(get_utc_timestamp_ns() - request_start_timestamp_ns)
+        try:
+            MetricRegistry().messages_endpoint_e2e_ms_histogram.record(
+                e2e_ms,
+                {"latency_optimisation_flow": _lof_attr, "status_code": status_code, **get_ctx_attributes()},
+            )
+        except Exception as metric_exc:
+            logger.warning(f"Failed to record messages endpoint e2e metric: {metric_exc}")
 
 
 @router.post(

--- a/letta/settings.py
+++ b/letta/settings.py
@@ -221,6 +221,10 @@ class Settings(BaseSettings):
     otel_preferred_temporality: Optional[int] = Field(
         default=1, ge=0, le=2, description="Exported metric temporality. {0: UNSPECIFIED, 1: DELTA, 2: CUMULATIVE}"
     )
+    # When True, exposes a Prometheus scrape endpoint at /metrics (cumulative temporality,
+    # independent of the OTLP push exporter). Intended to be scraped by a private/internal
+    # Prometheus — restrict network access at the infra layer. Works without an OTLP collector.
+    otel_metrics_prometheus_enabled: bool = False
     disable_tracing: bool = False
     llm_api_logging: bool = True
 

--- a/letta/settings.py
+++ b/letta/settings.py
@@ -221,10 +221,13 @@ class Settings(BaseSettings):
     otel_preferred_temporality: Optional[int] = Field(
         default=1, ge=0, le=2, description="Exported metric temporality. {0: UNSPECIFIED, 1: DELTA, 2: CUMULATIVE}"
     )
-    # When True, exposes a Prometheus scrape endpoint at /metrics (cumulative temporality,
-    # independent of the OTLP push exporter). Intended to be scraped by a private/internal
-    # Prometheus — restrict network access at the infra layer. Works without an OTLP collector.
+    # When True, starts a standalone Prometheus scrape server on its OWN port (not the API
+    # port), serving /metrics with cumulative temporality, independent of the OTLP push
+    # exporter. Runs on a dedicated port so infra can firewall it off from public traffic
+    # while letting an internal Prometheus scrape it. Works without an OTLP collector.
     otel_metrics_prometheus_enabled: bool = False
+    otel_metrics_prometheus_port: int = 9464  # OpenTelemetry's conventional Prometheus exporter port
+    otel_metrics_prometheus_addr: str = "0.0.0.0"  # bind address; restrict reachability at the network layer
     disable_tracing: bool = False
     llm_api_logging: bool = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ opentelemetry-api = "1.30.0"
 opentelemetry-sdk = "1.30.0"
 opentelemetry-instrumentation-requests = "0.51b0"
 opentelemetry-exporter-otlp = "1.30.0"
+opentelemetry-exporter-prometheus = "0.51b0"
 google-genai = {version = "^1.15.0", optional = true}
 faker = "^36.1.0"
 colorama = "^0.4.6"


### PR DESCRIPTION
## What & why

We A/B both `/messages` flows (`latencyOptimisationFlow` true vs false) to validate the Haiku-cascade optimisation, but had **no way to compare API latency by flow**, and **no metrics backend** to view it (no ClickHouse). This PR delivers both: a per-flow latency metric, and a way to actually see it.

## Three parts

### 1. Per-flow E2E latency metric
- **New histogram `hist_messages_endpoint_e2e_ms`** — complete latency of `POST /v1/agents/{id}/messages`, labeled `latency_optimisation_flow` (`"true"`/`"false"`) + `status_code`. Recorded in the `send_message` handler's `finally`. This is the headline comparable series, present for **both** flows (the existing `hist_haiku_cascade_request_ms` only fired when the flow was on).
- **`latency_optimisation_flow` set as an OTel request-context attribute** at the top of the handler. Context propagates *downward* into the agent loop, so it also labels the existing nested histograms for free: `hist_step_execution_time_ms`, `hist_llm_execution_time_ms`, `hist_ttft_ms`, `hist_message_output_tokens`, `hist_message_cost_usd`.

Why recorded in the handler, not the existing middleware E2E metric: the flag is in the request **body** (only known in the handler), and Starlette `BaseHTTPMiddleware` runs the route in a separate anyio task, so a context attr set in the handler doesn't propagate back up to the middleware.

### 2. Prometheus scrape endpoint (no collector / no ClickHouse)
- Add `opentelemetry-exporter-prometheus` (0.51b0, matches pinned otel 1.30.0).
- `setup_metrics()` can attach an OTLP push reader **and/or** a `PrometheusMetricReader`; metrics init is decoupled from tracing in `app.py` so it works with no OTLP endpoint.
- Prometheus reader forces cumulative temporality (required for `histogram_quantile`), independent of the OTLP DELTA setting.

### 3. Dedicated metrics port (DevOps request)
- Serve `/metrics` from a standalone `prometheus_client.start_http_server` on its **own port** (default **9464**), not the API port — so infra can firewall the metrics port off from public traffic independently.
- New settings: `otel_metrics_prometheus_enabled`, `otel_metrics_prometheus_port` (9464), `otel_metrics_prometheus_addr` (0.0.0.0).
- Bind failure (e.g. `uvicorn_workers > 1` racing the port) logs a warning instead of crashing the worker.
- Side benefit: the standalone server bypasses the API `--secure` password middleware, so scraping needs no token — reachability is controlled purely at the network layer.

## How to view / confirm the optimisation

```bash
export LETTA_OTEL_METRICS_PROMETHEUS_ENABLED=true   # metrics on :9464/metrics
```
```promql
# p95 E2E per flow — "true" should sit below "false"
histogram_quantile(0.95, sum by (le, latency_optimisation_flow) (rate(hist_messages_endpoint_e2e_ms_bucket[5m])))
```
DevOps scrapes `http://<letta-host>:9464/metrics` into an internal Prometheus.

## Reviewer notes
- Scope: **non-streaming** `POST /v1/agents/{id}/messages`, where the flag is currently threaded. `/messages/stream` and `/messages/async` not covered.
- **Run `poetry lock`** in CI for the new dependency (poetry wasn't available in the authoring env).
- All metrics no-op under pytest and when neither OTLP nor Prometheus is enabled — inert by default.
- The large diff in `agents.py` is mostly re-indentation from wrapping the handler body in `try/finally`; logic unchanged.
- Multi-worker: with `uvicorn_workers > 1` only one worker binds 9464 (logs a warning); full coverage needs prometheus_client multiprocess mode. Letta defaults to 1 worker.
- The Prometheus exporter may append a unit suffix to the histogram name (e.g. `..._ms_milliseconds_bucket`) — confirm the exact series via `curl :9464/metrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)