### PR TITLE
feat(haiku-cascade): cascade-v2 behind a gated rollout (now 50%) + per-LLM-call & DB-phase observability

### DIFF
--- a/docs/db-explain-messages-hot-path.sql
+++ b/docs/db-explain-messages-hot-path.sql
@@ -1,0 +1,163 @@
+-- ============================================================================
+-- EXPLAIN queries for every DB query on POST /v1/agents/{id}/messages
+-- ----------------------------------------------------------------------------
+-- Replace the example literals (org-1, agent-123, msg-1, the ::vector array)
+-- with real prod-sized values before running. Run each block against a
+-- production-sized table. For the vector queries, confirm the plan switches
+-- from `Seq Scan` + `Sort` to `Index Scan using ..._hnsw` once the index exists.
+-- See docs/db-queries-messages-hot-path.md for context per query.
+-- ============================================================================
+
+
+-- 1. user_manager.get_actor_or_default_async --------------------------------
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM users WHERE id = 'user-123' LIMIT 1;
+
+
+-- 2.0 agent_manager.get_agent_by_id_async — base row ------------------------
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT agents.* FROM agents
+WHERE agents.id = 'agent-123' AND agents.organization_id = 'org-1';
+
+-- 2.1 selectin: tools
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT tools.* FROM tools
+JOIN tools_agents ON tools.id = tools_agents.tool_id
+WHERE tools_agents.agent_id = 'agent-123';
+
+-- 2.2 selectin: sources
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT sources.* FROM sources
+JOIN sources_agents ON sources.id = sources_agents.source_id
+WHERE sources_agents.agent_id = 'agent-123';
+
+-- 2.3 selectin: core_memory (blocks)
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT block.* FROM block
+JOIN blocks_agents ON block.id = blocks_agents.block_id
+WHERE blocks_agents.agent_id = 'agent-123';
+
+-- 2.4 selectin: tags
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT agents_tags.* FROM agents_tags WHERE agents_tags.agent_id = 'agent-123';
+
+-- 2.5 selectin: identities
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT identities.* FROM identities
+JOIN identities_agents ON identities.id = identities_agents.identity_id
+WHERE identities_agents.agent_id = 'agent-123';
+
+-- 2.6 selectin: multi_agent_group
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT "group".* FROM "group" WHERE "group".manager_agent_id = 'agent-123';
+
+-- 2.7 selectin: tool_exec_environment_variables
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT agent_environment_variable.* FROM agent_environment_variable
+WHERE agent_environment_variable.agent_id = 'agent-123';
+
+-- 2.8 selectin: file_agents
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT file_agent.* FROM file_agent WHERE file_agent.agent_id = 'agent-123';
+
+
+-- 3.1 message_manager.get_message_by_id_async -------------------------------
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM messages WHERE id = 'msg-1' AND organization_id = 'org-1' LIMIT 1;
+
+-- 3.2 message_manager.get_messages_by_ids_async
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM messages
+WHERE id = ANY(ARRAY['msg-1','msg-2','msg-3']) AND organization_id = 'org-1';
+
+-- 3.3 create_many_messages_async — post-insert reselect
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM messages
+WHERE id = ANY(ARRAY['msg-1','msg-2']) ORDER BY created_at;
+
+
+-- 4. message_manager.size_async ---------------------------------------------
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT COUNT(1) FROM messages
+WHERE organization_id = 'org-1' AND agent_id = 'agent-123';
+
+
+-- 5. passage_manager.agent_passage_size_async -------------------------------
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT COUNT(1) FROM agent_passages
+WHERE organization_id = 'org-1' AND agent_id = 'agent-123';
+
+
+-- 6.1 _rebuild_memory_async: load blocks by IDs -----------------------------
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT block.* FROM block
+WHERE block.id = ANY(ARRAY['block-1','block-2']) AND block.organization_id = 'org-1';
+
+-- 6.2 _rebuild_memory_async: load file blocks   [needs files_agents(org,file_name)]
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT files_agents.* FROM files_agents
+WHERE file_name = ANY(ARRAY['a.pdf','b.txt']) AND organization_id = 'org-1';
+
+-- 6.3 _rebuild_memory_async: read system message before UPDATE
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM messages WHERE id = 'msg-sys-1' AND organization_id = 'org-1';
+
+
+-- 7. archival_memory_search — pgvector  [CRITICAL: needs HNSW index] --------
+-- agent passages only:
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM agent_passages
+WHERE organization_id = 'org-1' AND agent_id = 'agent-123'
+ORDER BY embedding <=> '[0.1,0.2,0.3]'::vector
+LIMIT 50;
+
+-- combined source + agent passages (UNION search path):
+EXPLAIN (ANALYZE, BUFFERS)
+WITH combined_passages AS (
+  SELECT id, text, embedding, created_at, agent_id, source_id, organization_id
+  FROM source_passages
+  WHERE organization_id = 'org-1'
+    AND source_id IN (SELECT source_id FROM sources_agents WHERE agent_id = 'agent-123')
+  UNION ALL
+  SELECT id, text, embedding, created_at, agent_id, NULL, organization_id
+  FROM agent_passages
+  WHERE organization_id = 'org-1' AND agent_id = 'agent-123'
+)
+SELECT * FROM combined_passages
+ORDER BY embedding <=> '[0.1,0.2,0.3]'::vector
+LIMIT 50;
+
+
+-- 8. core_memory_append / _replace — block read-modify-write ----------------
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM block WHERE id = 'block-1' AND organization_id = 'org-1';
+
+
+-- 9. set_in_context_messages_async — agent UPDATE ---------------------------
+-- (UPDATE by PK; the cost is the selectin relationship refresh — see §2 queries)
+EXPLAIN (ANALYZE, BUFFERS)
+UPDATE agents SET message_ids = '["msg-1","msg-2"]'::json, updated_at = NOW()
+WHERE id = 'agent-123';
+
+
+-- 12. summarizer: get_block_with_label_async --------------------------------
+-- (current: loads ALL agent blocks, filters label in Python)
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT block.* FROM block
+JOIN blocks_agents ON block.id = blocks_agents.block_id
+WHERE blocks_agents.agent_id = 'agent-123';
+
+-- (proposed: push label filter into SQL)
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT block.* FROM block
+JOIN blocks_agents ON block.id = blocks_agents.block_id
+WHERE blocks_agents.agent_id = 'agent-123'
+  AND blocks_agents.block_label = 'conversation_summary';
+
+
+-- ============================================================================
+-- Note: pure INSERTs (step_manager.log_step_async §10,
+-- telemetry_manager.create_provider_trace_async §11, block create §12) are
+-- omitted — no read/index analysis needed (FK-target PKs already exist).
+-- They are fire-and-forget candidates, not query-plan problems.
+-- ============================================================================

--- a/docs/db-queries-messages-hot-path.md
+++ b/docs/db-queries-messages-hot-path.md
@@ -1,0 +1,318 @@
+# DB Queries on `POST /v1/agents/{id}/messages`
+
+Every database query executed during a single `send_message` request, in request-flow
+order, with the generated SQL, a ready-to-run `EXPLAIN (ANALYZE, BUFFERS)` statement, and
+the index it needs (with current status).
+
+> Stack: SQLAlchemy async ORM over PostgreSQL (asyncpg) + pgvector.
+> Entry point: `letta/server/rest_api/routers/v1/agents.py::send_message` → `LettaAgent.step()`.
+
+---
+
+## Request flow (where queries originate)
+
+```
+send_message (agents.py:665)
+├─ user_manager.get_actor_or_default_async            → 1 SELECT (users)
+├─ agent_manager.get_agent_by_id_async                → 1 SELECT (agents) + N selectin relationship loads
+└─ LettaAgent.step() / _step()  ── loop over steps ──
+   ├─ helpers._prepare_in_context_messages_no_persist → message reads + create_many
+   ├─ _create_llm_request_data_async
+   │   ├─ message_manager.size_async                  → COUNT(messages)
+   │   ├─ passage_manager.agent_passage_size_async    → COUNT(agent_passages)
+   │   └─ _rebuild_memory_async                        → block reads + file-agent reads + (cond.) system-msg UPDATE
+   ├─ [tool exec] archival_memory_search              → pgvector similarity search   ⚠️ NO INDEX
+   ├─ [tool exec] core_memory_append / _replace       → block read-modify-write
+   ├─ message_manager.create_many_messages_async      → INSERT messages + reselect
+   ├─ agent_manager.set_in_context_messages_async     → UPDATE agents + full relationship refresh
+   ├─ step_manager.log_step_async                     → INSERT steps          (fire-and-forget candidate)
+   ├─ telemetry_manager.create_provider_trace_async   → INSERT provider_traces (fire-and-forget candidate)
+   └─ summarizer.summarize (conditional)              → block create/attach/update
+```
+
+---
+
+## 1. `user_manager.get_actor_or_default_async`
+Resolve the acting user from the `user_id` header.
+
+```sql
+SELECT * FROM users WHERE id = $1 LIMIT 1;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM users WHERE id = 'user-123' LIMIT 1;
+```
+**Index:** PK on `users.id` — ✅ exists.
+
+---
+
+## 2. `agent_manager.get_agent_by_id_async`  `agent_manager.py:1067`
+Load the agent. **All relationships use `lazy="selectin"`**, so even with
+`include_relationships=["multi_agent_group"]` the ORM fires a batch of follow-up SELECTs.
+
+### 2.0 Base agent row
+```sql
+SELECT agents.* FROM agents
+WHERE agents.id = $1 AND agents.organization_id = $2;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT agents.* FROM agents
+WHERE agents.id = 'agent-123' AND agents.organization_id = 'org-1';
+```
+**Index:** PK on `agents.id` — ✅. `organization_id` filter is the access predicate; PK lookup dominates so fine.
+
+### 2.1–2.N selectin relationship loads (each a separate query)
+| Relationship | Query | Needed index | Status |
+|---|---|---|---|
+| tools | `… tools JOIN tools_agents ON tool_id WHERE tools_agents.agent_id=$1` | `tools_agents(agent_id)` | ⚠️ only PK `(agent_id,tool_id)` — leading col OK for this read |
+| sources | `… sources JOIN sources_agents WHERE agent_id=$1` | `sources_agents(agent_id)` | ⚠️ only PK `(agent_id,source_id)` — leading col OK |
+| core_memory (blocks) | `… block JOIN blocks_agents WHERE agent_id=$1` | `blocks_agents(agent_id, block_id)` | ⚠️ has `(block_label,agent_id)` — **agent_id not leading** |
+| tags | `… agents_tags WHERE agent_id=$1` | `agents_tags(agent_id, tag)` | ✅ `ix_agents_tags_agent_id_tag` |
+| identities | `… identities JOIN identities_agents WHERE agent_id=$1` | `identities_agents(agent_id)` | ⚠️ only PK `(identity_id,agent_id)` — **agent_id not leading** |
+| groups / multi_agent_group | `… "group" WHERE manager_agent_id=$1` | `group(manager_agent_id)` | verify |
+| tool_exec_env_vars | `agent_environment_variable WHERE agent_id=$1` | `(agent_id)` | verify |
+| file_agents | `file_agent WHERE agent_id=$1` | `(agent_id)` | verify |
+
+```sql
+-- example: blocks selectin
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT block.* FROM block
+JOIN blocks_agents ON block.id = blocks_agents.block_id
+WHERE blocks_agents.agent_id = 'agent-123';
+```
+
+> ⚠️ **N+1-by-relationship**: with `include_relationships=None` the ORM loads *all* optional
+> relationships. The hot path only needs a subset. **Pass an explicit minimal
+> `include_relationships=[...]`** to skip loads that aren't used in the loop.
+
+---
+
+## 3. `_prepare_in_context_messages_no_persist_async`  `helpers.py`
+Loads the in-context message window and persists the new user message.
+
+### 3.1 `message_manager.get_message_by_id_async` (message_manager.py:45)
+```sql
+SELECT * FROM messages WHERE id = $1 AND organization_id = $2 LIMIT 1;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM messages WHERE id = 'msg-1' AND organization_id = 'org-1' LIMIT 1;
+```
+**Index:** PK on `messages.id` — ✅. Consider `messages(organization_id, id)` for the 2-col filter (minor).
+
+### 3.2 `message_manager.get_messages_by_ids_async` (message_manager.py:64)
+```sql
+SELECT * FROM messages
+WHERE id = ANY($1) AND organization_id = $2;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM messages
+WHERE id = ANY(ARRAY['msg-1','msg-2','msg-3']) AND organization_id = 'org-1';
+```
+**Index:** PK on `messages.id` handles the `ANY`. ✅
+
+### 3.3 `message_manager.create_many_messages_async` (message_manager.py:127)
+Bulk INSERT, then reselect ordered by `created_at`.
+```sql
+INSERT INTO messages (id, role, content, agent_id, organization_id, created_at, ...) VALUES (...), (...);
+SELECT * FROM messages WHERE id = ANY($1) ORDER BY created_at;
+```
+**Index:** reselect uses PK; ORDER BY covered by `ix_messages_created_at (created_at, id)` — ✅.
+
+---
+
+## 4. `message_manager.size_async`  `message_manager.py:345`
+Count messages for the agent (drives context-window math).
+```sql
+SELECT COUNT(1) FROM messages
+WHERE organization_id = $1 AND agent_id = $2;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT COUNT(1) FROM messages WHERE organization_id = 'org-1' AND agent_id = 'agent-123';
+```
+**Index:** ✅ `ix_messages_org_agent (organization_id, agent_id)` exists and covers this.
+
+---
+
+## 5. `passage_manager.agent_passage_size_async`  `passage_manager.py:1031`
+Count archival passages for the agent.
+```sql
+SELECT COUNT(1) FROM agent_passages
+WHERE organization_id = $1 AND agent_id = $2;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT COUNT(1) FROM agent_passages WHERE organization_id = 'org-1' AND agent_id = 'agent-123';
+```
+**Index:** ✅ `ix_agent_passages_org_agent (organization_id, agent_id)` exists.
+
+---
+
+## 6. `_rebuild_memory_async`  `base_agent.py:83`
+Rebuilds the system prompt from blocks. **No loop-based N+1** — blocks and file-agents are
+batch-loaded with `IN`. Latency (observed up to 26s) comes from large block `value` payloads,
+large system-message JSON diffs, and cache-invalidating rewrites — not query count.
+
+### 6.1 Load blocks by IDs (`block_manager.get_all_blocks_by_ids_async`, block_manager.py:241)
+```sql
+SELECT block.* FROM block
+WHERE block.id = ANY($1) AND block.organization_id = $2;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT block.* FROM block
+WHERE block.id = ANY(ARRAY['block-1','block-2']) AND block.organization_id = 'org-1';
+```
+**Index:** PK on `block.id` — ✅. `block(organization_id, id)` would help the access predicate (minor).
+
+### 6.2 Load file blocks (`files_agents_manager.py:148`)
+```sql
+SELECT files_agents.* FROM files_agents
+WHERE file_name = ANY($1) AND organization_id = $2;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT files_agents.* FROM files_agents
+WHERE file_name = ANY(ARRAY['a.pdf','b.txt']) AND organization_id = 'org-1';
+```
+**Index:** ⚠️ **MISSING** — add `files_agents(organization_id, file_name)`.
+
+### 6.3 Conditional system-message UPDATE (`message_manager.update_message_by_id_async`, message_manager.py:269)
+Only when memory changed. Read-modify-write (SELECT by PK, then UPDATE by PK).
+```sql
+SELECT * FROM messages WHERE id = $1 AND organization_id = $2;
+UPDATE messages SET content = $1, updated_at = NOW(), updated_by = $2 WHERE id = $3;
+```
+**Index:** PK on `messages.id` — ✅.
+
+---
+
+## 7. `archival_memory_search` tool — pgvector similarity  ⚠️ CRITICAL
+`sqlalchemy_base.py:375` (and the combined source+agent UNION in `agent_manager_helper.py:590`).
+Cosine-distance ordering over the `embedding` column.
+
+```sql
+SELECT * FROM agent_passages
+WHERE organization_id = $1 AND agent_id = $2
+ORDER BY embedding <=> $3::vector
+LIMIT 50;
+```
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT * FROM agent_passages
+WHERE organization_id = 'org-1' AND agent_id = 'agent-123'
+ORDER BY embedding <=> '[0.1,0.2,...]'::vector
+LIMIT 50;
+```
+Combined query (UNION of `source_passages` + `agent_passages`) orders the same way.
+
+**Index:** ⚠️ **MISSING — NO VECTOR INDEX on `agent_passages.embedding` or `source_passages.embedding`.**
+Every archival search is a **sequential scan + full sort**, O(n) in passage count. Add HNSW:
+```sql
+CREATE INDEX CONCURRENTLY ix_agent_passages_embedding_hnsw
+ON agent_passages USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+
+CREATE INDEX CONCURRENTLY ix_source_passages_embedding_hnsw
+ON source_passages USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+```
+(Use `<=>` = cosine distance → `vector_cosine_ops`. HNSW preferred over IVFFlat for frequent updates.)
+This is the single biggest DB win on the hot path.
+
+---
+
+## 8. `core_memory_append` / `core_memory_replace` → `block_manager.create_or_update_block_async`  `block_manager.py:43`
+Read-modify-write on a block (optimistic version lock).
+```sql
+SELECT * FROM block WHERE id = $1 AND organization_id = $2;          -- read
+UPDATE block SET value = $1, version = version + 1
+WHERE id = $2 AND organization_id = $3 AND version = $4;             -- write
+```
+**Index:** PK on `block.id` — ✅. Cannot be fire-and-forget (RMW with version lock).
+
+---
+
+## 9. `agent_manager.set_in_context_messages_async`  `agent_manager.py:1526`
+Updates `agents.message_ids`. Delegates to `update_agent_async`, which **re-runs the full
+selectin relationship batch from §2** twice (read + post-update refresh).
+```sql
+UPDATE agents SET message_ids = $1::json, updated_at = NOW(), last_updated_by_id = $2 WHERE id = $3;
+-- + full selectin relationship reload (tools/sources/blocks/identities/...)
+```
+**Index:** UPDATE by PK — ✅. The cost is the **relationship refresh**, gated by the same
+join-table indexes flagged in §2 (blocks_agents / identities_agents / tools_agents / sources_agents).
+
+---
+
+## 10. `step_manager.log_step_async`  `step_manager.py:105`  — pure INSERT
+```sql
+INSERT INTO steps (id, organization_id, agent_id, model, completion_tokens, prompt_tokens, total_tokens, ...) VALUES (...);
+```
+**Index:** PK + FK targets (org/job/provider PKs) — ✅. **Fire-and-forget candidate** (no read before write).
+Optional reporting indexes (not on hot path): `steps(organization_id, agent_id)`, `steps(trace_id)`.
+
+---
+
+## 11. `telemetry_manager.create_provider_trace_async`  `telemetry_manager.py:24`  — pure INSERT
+```sql
+INSERT INTO provider_traces (id, organization_id, request_json, response_json, step_id, created_at, ...) VALUES (...);
+```
+**Index:** ✅ `ix_step_id (step_id)` exists. **Fire-and-forget candidate** — this is observability
+data and should never block the user response (it was 15s in one prod trace).
+
+---
+
+## 12. Summarizer (conditional, when buffer overflows)  `ephemeral_summary_agent.py`
+- block lookup by label → `get_block_with_label_async` (§ below)
+- block create (if missing) → INSERT block  *(pure insert)*
+- block attach (if new) → INSERT blocks_agents + UPDATE agents *(RMW)*
+- block value update → UPDATE block.value + version *(RMW)*
+
+### `agent_manager.get_block_with_label_async`  `agent_manager.py:1881`
+⚠️ Loads the agent + **all** core_memory blocks via selectin, then filters by label **in Python**.
+```sql
+SELECT block.* FROM block JOIN blocks_agents ON block.id = blocks_agents.block_id
+WHERE blocks_agents.agent_id = $1;   -- then Python loops to find label
+```
+**Index:** wants `blocks_agents(agent_id, block_id)` — ⚠️ only `(block_label, agent_id)` exists.
+**Optimization:** filter by label in SQL instead of Python (push `block_label = $2` into the WHERE).
+
+---
+
+## Index gap summary (actionable)
+
+| # | Priority | Table | Recommended index | Status | Why |
+|---|---|---|---|---|---|
+| 1 | 🔴 **Critical** | `agent_passages` | `USING hnsw (embedding vector_cosine_ops)` | **MISSING** | archival_memory_search = seq-scan + full sort, O(n) |
+| 2 | 🔴 **Critical** | `source_passages` | `USING hnsw (embedding vector_cosine_ops)` | **MISSING** | same, on the UNION search path |
+| 3 | 🟠 High | `files_agents` | `(organization_id, file_name)` | **MISSING** | hit on every `_rebuild_memory_async` |
+| 4 | 🟠 High | `blocks_agents` | `(agent_id, block_id)` | partial (`(block_label,agent_id)`) | agent_id not leading → relationship loads + RMW deletes |
+| 5 | 🟡 Med | `identities_agents` | `(agent_id)` | PK `(identity_id,agent_id)` only | selectin load on every agent fetch |
+| 6 | 🟡 Med | `tools_agents` | `(agent_id)` | PK `(agent_id,tool_id)` — leading OK | selectin load (PK leading col already serves) |
+| 7 | 🟡 Med | `sources_agents` | `(agent_id, source_id)` | PK `(agent_id,source_id)` — leading OK | selectin load (PK already serves) |
+| 8 | 🟢 Low | `messages` | `(organization_id, id)` | PK on id | minor — 2-col point lookups |
+| 9 | 🟢 Low | `block` | `(organization_id, id)` | PK on id | minor — access predicate |
+
+### Non-index wins (bigger than most indexes here)
+- **Make `step` + `provider_trace` inserts fire-and-forget** — they were 13–15s in prod and block the response for zero user value.
+- **Trim `get_agent_by_id_async` / `set_in_context_messages_async` relationship loads** — pass explicit minimal `include_relationships`; the selectin batch + post-update refresh is the recurring cost, not any single query.
+- **Push the `block_label` filter into SQL** in `get_block_with_label_async` instead of Python-side filtering.
+
+### Suggested first PR (highest ROI, lowest risk)
+```sql
+-- 1 & 2: the only O(n) → O(log n) changes on the path
+CREATE INDEX CONCURRENTLY ix_agent_passages_embedding_hnsw
+  ON agent_passages USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+CREATE INDEX CONCURRENTLY ix_source_passages_embedding_hnsw
+  ON source_passages USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+
+-- 3 & 4: cheap B-tree adds, hit every request
+CREATE INDEX CONCURRENTLY ix_files_agents_org_file_name ON files_agents (organization_id, file_name);
+CREATE INDEX CONCURRENTLY ix_blocks_agents_agent_id ON blocks_agents (agent_id, block_id);
+```
+
+> Validate each with the `EXPLAIN (ANALYZE, BUFFERS)` statements above on a prod-sized table
+> before and after. For the vector indexes, confirm the plan switches from `Seq Scan` + `Sort`
+> to an `Index Scan using …_hnsw`.

--- a/letta/agents/base_agent.py
+++ b/letta/agents/base_agent.py
@@ -48,6 +48,7 @@ class BaseAgent(ABC):
         self.passage_manager = PassageManager()
         self.actor = actor
         self.logger = get_logger(agent_id)
+        self._task_id: Optional[str] = None  # set per-request by step(); used to gate latency logs
 
     @abstractmethod
     async def step(self, input_messages: List[MessageCreate], max_steps: int = DEFAULT_MAX_STEPS) -> LettaResponse:
@@ -102,7 +103,8 @@ class BaseAgent(ABC):
             curr_memory_str = agent_state.memory.compile()
             curr_system_message_text = curr_system_message.content[0].text
             if curr_memory_str in curr_system_message_text:
-                logger.info(f"[REBUILD_TIMING] agent_id={agent_state.id} refresh_ms={_refresh_ms} changed=false")
+                if self._task_id:
+                    logger.info(f"[REBUILD_TIMING] task_id={self._task_id} agent_id={agent_state.id} refresh_ms={_refresh_ms} changed=false")
                 return in_context_messages
 
             memory_edit_timestamp = get_utc_time()
@@ -192,17 +194,19 @@ class BaseAgent(ABC):
                     curr_system_message.id, message_update=MessageUpdate(content=new_system_message_str), actor=self.actor
                 )
                 _write_ms = ns_to_ms(get_utc_timestamp_ns() - _t_write)
-                logger.info(
-                    f"[REBUILD_TIMING] agent_id={agent_state.id} refresh_ms={_refresh_ms} "
-                    f"counts_ms={_counts_ms} sysmsg_write_ms={_write_ms} changed=true"
-                )
+                if self._task_id:
+                    logger.info(
+                        f"[REBUILD_TIMING] task_id={self._task_id} agent_id={agent_state.id} refresh_ms={_refresh_ms} "
+                        f"counts_ms={_counts_ms} sysmsg_write_ms={_write_ms} changed=true"
+                    )
                 return [new_system_message] + in_context_messages[1:]
 
             else:
-                logger.info(
-                    f"[REBUILD_TIMING] agent_id={agent_state.id} refresh_ms={_refresh_ms} "
-                    f"counts_ms={_counts_ms} sysmsg_write_ms=0 changed=false_nodiff"
-                )
+                if self._task_id:
+                    logger.info(
+                        f"[REBUILD_TIMING] task_id={self._task_id} agent_id={agent_state.id} refresh_ms={_refresh_ms} "
+                        f"counts_ms={_counts_ms} sysmsg_write_ms=0 changed=false_nodiff"
+                    )
                 return in_context_messages
         except:
             logger.exception(f"Failed to rebuild memory for agent id={agent_state.id} and actor=({self.actor.id}, {self.actor.name})")

--- a/letta/agents/base_agent.py
+++ b/letta/agents/base_agent.py
@@ -5,7 +5,7 @@ import openai
 
 from letta.constants import DEFAULT_MAX_STEPS
 from letta.helpers import ToolRulesSolver
-from letta.helpers.datetime_helpers import get_utc_time
+from letta.helpers.datetime_helpers import get_utc_time, get_utc_timestamp_ns, ns_to_ms
 from letta.log import get_logger
 from letta.schemas.agent import AgentState
 from letta.schemas.enums import MessageStreamStatus
@@ -93,26 +93,28 @@ class BaseAgent(ABC):
         """
         try:
             # [DB Call] loading blocks (modifies: agent_state.memory.blocks)
+            _t_refresh = get_utc_timestamp_ns()
             await self.agent_manager.refresh_memory_async(agent_state=agent_state, actor=self.actor)
+            _refresh_ms = ns_to_ms(get_utc_timestamp_ns() - _t_refresh)
 
             # TODO: This is a pretty brittle pattern established all over our code, need to get rid of this
             curr_system_message = in_context_messages[0]
             curr_memory_str = agent_state.memory.compile()
             curr_system_message_text = curr_system_message.content[0].text
             if curr_memory_str in curr_system_message_text:
-                logger.debug(
-                    f"Memory hasn't changed for agent id={agent_state.id} and actor=({self.actor.id}, {self.actor.name}), skipping system prompt rebuild"
-                )
+                logger.info(f"[REBUILD_TIMING] agent_id={agent_state.id} refresh_ms={_refresh_ms} changed=false")
                 return in_context_messages
 
             memory_edit_timestamp = get_utc_time()
 
             # [DB Call] size of messages and archival memories
             # todo: blocking for now
+            _t_counts = get_utc_timestamp_ns()
             if num_messages is None:
                 num_messages = await self.message_manager.size_async(actor=self.actor, agent_id=agent_state.id)
             if num_archival_memories is None:
                 num_archival_memories = await self.passage_manager.agent_passage_size_async(actor=self.actor, agent_id=agent_state.id)
+            _counts_ms = ns_to_ms(get_utc_timestamp_ns() - _t_counts)
 
             new_system_message_str = compile_system_message(
                 system_prompt=agent_state.system,
@@ -185,12 +187,22 @@ class BaseAgent(ABC):
                     return in_context_messages
 
                 # [DB Call] Update Messages
+                _t_write = get_utc_timestamp_ns()
                 new_system_message = await self.message_manager.update_message_by_id_async(
                     curr_system_message.id, message_update=MessageUpdate(content=new_system_message_str), actor=self.actor
+                )
+                _write_ms = ns_to_ms(get_utc_timestamp_ns() - _t_write)
+                logger.info(
+                    f"[REBUILD_TIMING] agent_id={agent_state.id} refresh_ms={_refresh_ms} "
+                    f"counts_ms={_counts_ms} sysmsg_write_ms={_write_ms} changed=true"
                 )
                 return [new_system_message] + in_context_messages[1:]
 
             else:
+                logger.info(
+                    f"[REBUILD_TIMING] agent_id={agent_state.id} refresh_ms={_refresh_ms} "
+                    f"counts_ms={_counts_ms} sysmsg_write_ms=0 changed=false_nodiff"
+                )
                 return in_context_messages
         except:
             logger.exception(f"Failed to rebuild memory for agent id={agent_state.id} and actor=({self.actor.id}, {self.actor.name})")

--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -1362,8 +1362,12 @@ class LettaAgent(BaseAgent):
             new_in_context_messages, updated = self.summarizer.summarize(
                 in_context_messages=in_context_messages, new_letta_messages=new_letta_messages
             )
+        _t_setctx = get_utc_timestamp_ns()
         await self.agent_manager.set_in_context_messages_async(
             agent_id=self.agent_id, message_ids=[m.id for m in new_in_context_messages], actor=self.actor
+        )
+        logger.info(
+            f"[CTXWIN_TIMING] agent_id={self.agent_id} set_in_context_ms={ns_to_ms(get_utc_timestamp_ns() - _t_setctx)} summarized={updated}"
         )
 
         return new_in_context_messages

--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -459,6 +459,10 @@ class LettaAgent(BaseAgent):
         # Handle provider switching based on experiment flags
         self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override)
 
+        # Stash task_id on the instance so agent-internal helpers (_rebuild_memory_async,
+        # _rebuild_context_window) can tag their latency logs. Agent is per-request, so safe.
+        self._task_id = task_id
+
         _ctx_prep_start = get_utc_timestamp_ns() if task_id else None
         async with AsyncTimer() as _t:
             current_in_context_messages, new_in_context_messages = await _prepare_in_context_messages_no_persist_async(
@@ -1366,9 +1370,11 @@ class LettaAgent(BaseAgent):
         await self.agent_manager.set_in_context_messages_async(
             agent_id=self.agent_id, message_ids=[m.id for m in new_in_context_messages], actor=self.actor
         )
-        logger.info(
-            f"[CTXWIN_TIMING] agent_id={self.agent_id} set_in_context_ms={ns_to_ms(get_utc_timestamp_ns() - _t_setctx)} summarized={updated}"
-        )
+        if self._task_id:
+            logger.info(
+                f"[CTXWIN_TIMING] task_id={self._task_id} agent_id={self.agent_id} "
+                f"set_in_context_ms={ns_to_ms(get_utc_timestamp_ns() - _t_setctx)} summarized={updated}"
+            )
 
         return new_in_context_messages
 

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -696,12 +696,13 @@ async def send_message(
         # TODO: This is redundant, remove soon
         _t_agent = get_utc_timestamp_ns()
         agent = await server.agent_manager.get_agent_by_id_async(agent_id, actor, include_relationships=["multi_agent_group"])
-        logger.warning(
-            f"[TASK_LATENCY] task_id={request.task_id or 'N/A'} phase=actor_load duration_ms={ns_to_ms(_t_agent - _t_actor)}"
-        )
-        logger.warning(
-            f"[TASK_LATENCY] task_id={request.task_id or 'N/A'} phase=agent_load duration_ms={ns_to_ms(get_utc_timestamp_ns() - _t_agent)}"
-        )
+        if request.task_id:
+            logger.warning(
+                f"[TASK_LATENCY] task_id={request.task_id} phase=actor_load duration_ms={ns_to_ms(_t_agent - _t_actor)}"
+            )
+            logger.warning(
+                f"[TASK_LATENCY] task_id={request.task_id} phase=agent_load duration_ms={ns_to_ms(get_utc_timestamp_ns() - _t_agent)}"
+            )
         agent_eligible = agent.multi_agent_group is None or agent.multi_agent_group.manager_type in ["sleeptime", "voice_sleeptime"]
         model_compatible = agent.llm_config.model_endpoint_type in ["anthropic", "openai", "together", "google_ai", "google_vertex"]
 

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -691,9 +691,17 @@ async def send_message(
     # middleware) because the flag is only known inside the handler.
     status_code = 200
     try:
+        _t_actor = get_utc_timestamp_ns()
         actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
         # TODO: This is redundant, remove soon
+        _t_agent = get_utc_timestamp_ns()
         agent = await server.agent_manager.get_agent_by_id_async(agent_id, actor, include_relationships=["multi_agent_group"])
+        logger.warning(
+            f"[TASK_LATENCY] task_id={request.task_id or 'N/A'} phase=actor_load duration_ms={ns_to_ms(_t_agent - _t_actor)}"
+        )
+        logger.warning(
+            f"[TASK_LATENCY] task_id={request.task_id or 'N/A'} phase=agent_load duration_ms={ns_to_ms(get_utc_timestamp_ns() - _t_agent)}"
+        )
         agent_eligible = agent.multi_agent_group is None or agent.multi_agent_group.manager_type in ["sleeptime", "voice_sleeptime"]
         model_compatible = agent.llm_config.model_endpoint_type in ["anthropic", "openai", "together", "google_ai", "google_vertex"]
 


### PR DESCRIPTION
## Summary

Ships the full Haiku-cascade **v2** behind a **10% rollout gate**, plus the observability needed to measure it. One deployable branch.

## 1. Cascade v2 (gated to 10% of users)

The previous "gate-only" cascade let Haiku see `send_message` and prematurely pick it at intermediate steps → the quality gate discarded the response and re-ran on the primary model. Production traces showed this costing **~7–18s per multi-step request** (`retried_steps=2`, ~29k wasted tokens).

- **Tool restriction** — strip `send_message` from Haiku's tool list (keep `tool_choice="any"`), so it *can't* pick it → retries go to ~0. Includes an empty-tool guard for the tool-rules-forced edge case.
- **8s timeout circuit-breaker** — wrap each Haiku call in `asyncio.wait_for`; on timeout, fall back to primary. Bounds damage when Bedrock degrades (we observed 24–33s/call during an ap-south-1 service event).
- **Global Haiku 4.5 inference profile** — `global.anthropic.claude-haiku-4-5-20251001-v1:0` routes worldwide instead of the single-region AIP that degraded.
- **`response=None` safety guard** after the timeout fallback (prevents NameError).
- **Summarizer race fix** — catch `IntegrityError` on concurrent `conversation_summary` block attach (was crashing with `UniqueViolationError`).

### Rollout gate
`_CASCADE_ROLLOUT_PCT = 10` — cascade honored for 10% of users, bucketed deterministically by `user_id % 100` (stable per user). Test user always-on; non-numeric/missing id fails closed. **One knob:** ramp `10 → 50 → 100`, or set `0` for instant full rollback. Gated-off users log `GATED_OFF ... rollout_pct=10` and run primary-only.

## 2. Observability

- **`hist_llm_call_ms`** — per-LLM-call latency (one record per provider call, not endpoint e2e), partitioned by `use_bedrock_experiment` → compare Bedrock vs the direct/inference-proxy path in isolation.
- **DB phase timing logs** (gated on `task_id` presence):
  - `[TASK_LATENCY] phase=actor_load / phase=agent_load` — initial load + relationship batch
  - `[REBUILD_TIMING]` — splits `_rebuild_memory_async` into refresh / counts / sysmsg-write
  - `[CTXWIN_TIMING]` — isolates `set_in_context` (agent UPDATE + relationship refresh)
- `timeout_steps` added to the cascade `SUMMARY`; `ATTEMPT_HAIKU` downgraded warning→info; all `DEBUG` prints removed.

## 3. Reference docs (`docs/`)
- `db-queries-messages-hot-path.md` — every query on the path with SQL + EXPLAIN + index analysis.
- `db-explain-messages-hot-path.sql` — runnable EXPLAIN suite.
- `agent-passages-db-problem.md` — the 19 TB / 1.06B-row vector-table problem and remediation options (separate track).

## What to watch after deploy (10% cohort)
- `SUMMARY ... retried_steps=0 wasted_haiku_tokens=0` → tool restriction working
- `timeout_steps` → Bedrock-degradation frequency
- `hist_llm_call_ms` by `use_bedrock_experiment` → provider latency
- Compare cohort latency vs the gated-off 90% control

## Reviewer notes
- Behavior change is **gated to 10%** and instantly reversible via `_CASCADE_ROLLOUT_PCT`.
- **Deploy check:** confirm the Bedrock **global** inference profile is enabled for the prod AWS account before shipping (validated in test, verify in deploy env).