### PR TITLE
hotfix(haiku-cascade): stop runaway loop — gate-only (tool restriction still live in prod after #125 revert)

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -553,7 +553,7 @@ class LettaAgent(BaseAgent):
                         f"haiku_model={_haiku_model} "
                         f"rule=step0_on_primary_then_tool_calls_on_haiku_send_message_never_on_haiku "
                         f"primary_reserved_tools={sorted(_PRIMARY_RESERVED_TOOLS)} "
-                        f"strategy=skip_step0_plus_tool_list_restriction_plus_post_call_gate "
+                        f"strategy=skip_step0_plus_post_call_gate_only_plus_timeout "
                         f"timeout_s={_HAIKU_TIMEOUT_SECONDS}"
                     )
                     MetricRegistry().haiku_cascade_request_counter.add(1, _cascade_attrs(state="enabled"))
@@ -636,13 +636,17 @@ class LettaAgent(BaseAgent):
                 # Cascade requested but no Haiku model mapped — record so we can detect misconfigs.
                 MetricRegistry().haiku_cascade_step_counter.add(1, _cascade_attrs(outcome="primary_no_haiku_model"))
 
-            # Haiku tool restriction: strip send_message from Haiku's tool list so it
-            # cannot pick it prematurely. tool_choice stays "any" (forced tool call) —
-            # Haiku must call a memory/context tool and cannot call send_message.
-            # Gate below is kept as a safety net for edge cases.
-            # IMPORTANT: do NOT downgrade tool_choice to "auto" — that was the original
-            # bug that let Haiku return plain text on ~75% of steps.
-            _excluded_for_haiku: Optional[frozenset] = _PRIMARY_RESERVED_TOOLS if _step_used_haiku else None
+            # Strategy: gate-only (NOT tool-list restriction).
+            #
+            # Haiku gets the FULL tool list (including send_message). The post-call gate
+            # below enforces "send_message runs on primary": if Haiku picks send_message,
+            # we discard and re-run the step on the primary model.
+            #
+            # We do NOT strip send_message from Haiku. Stripping it removed the only
+            # trigger for the primary handoff (the gate only fires when Haiku picks
+            # send_message), so the agent could never terminate on a Haiku step and looped
+            # to max_steps (prod task 323737721: 42+ archival_memory_insert steps, ~150s).
+            _excluded_for_haiku: Optional[frozenset] = None
 
             _llm_start = get_utc_timestamp_ns() if task_id else None
             _haiku_timed_out: bool = False


### PR DESCRIPTION
## 🚨 Why this is urgent

`main-custom` is **currently running the runaway-causing tool restriction at 10%**. Reverting #125 (via #126) did **not** remove it — the cascade-v2 code reached `main-custom` through another merge path, so the tool restriction (`_excluded_for_haiku = _PRIMARY_RESERVED_TOOLS`) and `_CASCADE_ROLLOUT_PCT = 10` are both still live.

## The bug

Stripping `send_message` from Haiku's tool list removed the **only** trigger for the primary handoff. The post-call gate only fires when Haiku picks `send_message`; with it stripped, the gate never fires, and since only step 0 runs on primary, any multi-step request that does memory work before replying **can never terminate** — it loops to `max_steps=50`.

Production evidence: task `323737721` — 42+ steps, all `archival_memory_insert` on Haiku, ~150s, no `send_message`, writing ~40 junk archival rows.

## The fix (1 line)

`_excluded_for_haiku = None` → gate-only. Haiku keeps the full tool list; if it picks `send_message` the gate retries on primary and the turn **terminates correctly**. This is the known-good behavior (pre-restriction). Rollout stays at 10%, 8s timeout circuit-breaker unchanged.

## Trade-off

Re-introduces the occasional premature-`send_message` retry (~7–18s on some multi-step requests) — acceptable vs a 150s runaway + archival-memory pollution.

## Verify after deploy (10% cohort)
- `SUMMARY total_steps` stays normal (not climbing to 50)
- No long runs of repeated `archival_memory_insert` without `send_message`
- `RETRY_ON_PRIMARY haiku_picked=send_message` reappears — this is now the **healthy** signal (handoff working)