### PR TITLE
hotfix(bedrock): stop forwarding output_config to Bedrock InvokeModel

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -319,7 +319,12 @@ class AnthropicClient(LLMClientBase):
                         _requested_model,
                     )
             if "output_config" in request_data:
-                bedrock_body["output_config"] = request_data["output_config"]
+                # Bedrock's InvokeModel schema rejects output_config outright
+                # (ValidationException: output_config.effort: Extra inputs are not permitted),
+                # unlike the direct Anthropic API and Vertex — drop it rather than 400 the call.
+                logger.warning(
+                    "[BEDROCK] Dropping output_config field — Bedrock does not support it yet"
+                )
 
             # Run synchronous boto3 call in a thread to avoid blocking the event loop
             def _invoke():


### PR DESCRIPTION
## Summary
- Live incident: since the Sonnet 5 thinking-gate exemption (#134) landed in prod, real Sonnet 5 + Bedrock traffic (`use_bedrock_experiment=true`, `output_config: {"effort": "low"}`) is 500ing for user 92744418 — confirmed in go-ai-chat logs for chat orders 367210830 and 367206294:
  `error from LLM {"detail":"Unhandled LLM error: An error occurred (ValidationException) when calling the InvokeModel operation: output_config.effort: Extra inputs are not permitted"}`
- Root cause: `AnthropicClient.request_async` forwards `output_config` into the Bedrock request body unconditionally, but Bedrock's InvokeModel schema doesn't accept that field at all yet (already noted elsewhere in this file re: the `effort` field not being supported on Bedrock). This drops `output_config` before building `bedrock_body` instead of passing it through and 400ing.

## Test plan
- [x] File parses cleanly
- [ ] Repro the failing curl (model=claude-sonnet-5, use_bedrock_experiment=true, output_config effort low) against Bedrock and confirm it no longer 400s
- [ ] Confirm chat orders for user 92744418 stop 500ing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)