### PR TITLE
feat(bedrock): add debug log for final Bedrock request parameters

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -321,6 +321,19 @@ class AnthropicClient(LLMClientBase):
             if "output_config" in request_data:
                 bedrock_body["output_config"] = request_data["output_config"]
 
+            logger.info(
+                "[BEDROCK] Final request — model_id=%s thinking=%s max_tokens=%s temperature=%s "
+                "output_config=%s tool_choice=%s num_messages=%s num_tools=%s",
+                model_id,
+                bedrock_body.get("thinking"),
+                bedrock_body.get("max_tokens"),
+                bedrock_body.get("temperature"),
+                bedrock_body.get("output_config"),
+                bedrock_body.get("tool_choice"),
+                len(bedrock_body.get("messages", [])),
+                len(bedrock_body.get("tools", [])),
+            )
+
             # Run synchronous boto3 call in a thread to avoid blocking the event loop
             def _invoke():
                 resp = bedrock_client.invoke_model(

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -322,8 +322,9 @@ class AnthropicClient(LLMClientBase):
                 bedrock_body["output_config"] = request_data["output_config"]
 
             logger.info(
-                "[BEDROCK] Final request — model_id=%s thinking=%s max_tokens=%s temperature=%s "
+                "[BEDROCK] Final request — user_id=%s model_id=%s thinking=%s max_tokens=%s temperature=%s "
                 "output_config=%s tool_choice=%s num_messages=%s num_tools=%s",
+                getattr(self, "at_user_id", None),
                 model_id,
                 bedrock_body.get("thinking"),
                 bedrock_body.get("max_tokens"),


### PR DESCRIPTION
Logs model_id, thinking, max_tokens, temperature, output_config, tool_choice, and message/tool counts right before invoke_model so the exact request sent to Bedrock is visible in logs.

