### PR TITLE
feat: add Google AI (Gemini) provider routing via llm_provider + thin…

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -81,6 +81,13 @@ def _log_step_timing(step: str, elapsed_ms: float, **kwargs) -> None:
 # must always be honored for that model regardless of user id.
 _THINKING_GATED_USER_IDS: frozenset = frozenset({"92744418"})
 
+# Gemini thinking level → approximate token budget
+_GEMINI_THINKING_LEVEL_TO_BUDGET: dict = {
+    "low": 1024,
+    "medium": 8192,
+    "high": 24576,
+}
+
 
 def _thinking_override_allowed(at_user_id: Optional[str], model: Optional[str]) -> bool:
     if at_user_id in _THINKING_GATED_USER_IDS:
@@ -212,6 +219,7 @@ class LettaAgent(BaseAgent):
         use_vertex_experiment: bool,
         use_bedrock_experiment: bool,
         model_override: Optional[str] = None,
+        llm_provider: Optional[str] = None,
     ):
         """Apply dynamic provider switching based on experiment flags."""
         # Runtime model override: swap the model name before any endpoint-type remapping
@@ -219,6 +227,11 @@ class LettaAgent(BaseAgent):
         # overridden model.
         if model_override:
             agent_state.llm_config.model = model_override
+
+        # Explicit provider override takes precedence over vertex/bedrock experiment flags.
+        if llm_provider == "google":
+            agent_state.llm_config.model_endpoint_type = "google_ai"
+            return
 
         original_endpoint_type = agent_state.llm_config.model_endpoint_type
         original_model = agent_state.llm_config.model
@@ -251,9 +264,11 @@ class LettaAgent(BaseAgent):
         model_override: Optional[str] = None,
         user_cohort: Optional[str] = None,
         thinking: Optional[dict] = None,
+        thinking_config: Optional[dict] = None,
         output_config: Optional[dict] = None,
         task_id: Optional[str] = None,
         latency_optimisation_flow: bool = False,
+        llm_provider: Optional[str] = None,
     ) -> LettaResponse:
         agent_state = await self.agent_manager.get_agent_by_id_async(
             agent_id=self.agent_id, include_relationships=["tools", "memory", "tool_exec_environment_variables"], actor=self.actor
@@ -268,9 +283,11 @@ class LettaAgent(BaseAgent):
             model_override=model_override,
             user_cohort=user_cohort,
             thinking=thinking,
+            thinking_config=thinking_config,
             output_config=output_config,
             task_id=task_id,
             latency_optimisation_flow=latency_optimisation_flow,
+            llm_provider=llm_provider,
         )
         return _create_letta_response(
             new_in_context_messages=new_in_context_messages,
@@ -293,14 +310,16 @@ class LettaAgent(BaseAgent):
         model_override: Optional[str] = None,
         user_cohort: Optional[str] = None,
         thinking: Optional[dict] = None,
+        thinking_config: Optional[dict] = None,
         output_config: Optional[dict] = None,
+        llm_provider: Optional[str] = None,
     ):
         agent_state = await self.agent_manager.get_agent_by_id_async(
             agent_id=self.agent_id, include_relationships=["tools", "memory", "tool_exec_environment_variables"], actor=self.actor
         )
 
         # Handle provider switching based on experiment flags
-        self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override)
+        self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override, llm_provider=llm_provider)
 
         async with AsyncTimer() as _t:
             current_in_context_messages, new_in_context_messages = await _prepare_in_context_messages_no_persist_async(
@@ -343,6 +362,7 @@ class LettaAgent(BaseAgent):
                     use_bedrock_experiment=use_bedrock_experiment,
                     step_index=i,
                     thinking=thinking,
+                    thinking_config=thinking_config,
                     output_config=output_config,
                 )
             )
@@ -478,9 +498,11 @@ class LettaAgent(BaseAgent):
         model_override: Optional[str] = None,
         user_cohort: Optional[str] = None,
         thinking: Optional[dict] = None,
+        thinking_config: Optional[dict] = None,
         output_config: Optional[dict] = None,
         task_id: Optional[str] = None,
         latency_optimisation_flow: bool = False,
+        llm_provider: Optional[str] = None,
     ) -> Tuple[List[Message], List[Message], Optional[LettaStopReason], LettaUsageStatistics]:
         """
         Carries out an invocation of the agent loop. In each step, the agent
@@ -490,7 +512,7 @@ class LettaAgent(BaseAgent):
             4. Processes the response
         """
         # Handle provider switching based on experiment flags
-        self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override)
+        self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override, llm_provider=llm_provider)
 
         # Stash task_id on the instance so agent-internal helpers (_rebuild_memory_async,
         # _rebuild_context_window) can tag their latency logs. Agent is per-request, so safe.
@@ -663,7 +685,7 @@ class LettaAgent(BaseAgent):
                 _haiku_coro = self._build_and_request_from_llm(
                     current_in_context_messages, new_in_context_messages, agent_state, llm_client, tool_rules_solver, agent_step_span,
                     use_vertex_experiment=use_vertex_experiment, use_bedrock_experiment=use_bedrock_experiment, step_index=i,
-                    thinking=thinking, output_config=output_config,
+                    thinking=thinking, thinking_config=thinking_config, output_config=output_config,
                     excluded_tool_names=_excluded_for_haiku,
                 )
                 # Timeout circuit-breaker: if Haiku is slower than _HAIKU_TIMEOUT_SECONDS
@@ -708,7 +730,7 @@ class LettaAgent(BaseAgent):
                     await self._build_and_request_from_llm(
                         _pre_call_current_messages, _pre_call_new_messages, agent_state, llm_client, tool_rules_solver, agent_step_span,
                         use_vertex_experiment=use_vertex_experiment, use_bedrock_experiment=use_bedrock_experiment, step_index=i,
-                        thinking=thinking, output_config=output_config,
+                        thinking=thinking, thinking_config=thinking_config, output_config=output_config,
                     )
                 )
                 if task_id and _llm_timeout_retry_start:
@@ -781,7 +803,7 @@ class LettaAgent(BaseAgent):
                         await self._build_and_request_from_llm(
                             _pre_call_current_messages, _pre_call_new_messages, agent_state, llm_client, tool_rules_solver, agent_step_span,
                             use_vertex_experiment=use_vertex_experiment, use_bedrock_experiment=use_bedrock_experiment, step_index=i,
-                            thinking=thinking, output_config=output_config,
+                            thinking=thinking, thinking_config=thinking_config, output_config=output_config,
                         )
                     )
                     if task_id and _llm_retry_start:
@@ -1023,7 +1045,9 @@ class LettaAgent(BaseAgent):
         model_override: Optional[str] = None,
         user_cohort: Optional[str] = None,
         thinking: Optional[dict] = None,
+        thinking_config: Optional[dict] = None,
         output_config: Optional[dict] = None,
+        llm_provider: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
         """
         Carries out an invocation of the agent loop in a streaming fashion that yields partial tokens.
@@ -1038,7 +1062,7 @@ class LettaAgent(BaseAgent):
         )
 
         # Handle provider switching based on experiment flags
-        self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override)
+        self._apply_provider_switching(agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override, llm_provider=llm_provider)
 
         current_in_context_messages, new_in_context_messages = await _prepare_in_context_messages_no_persist_async(
             input_messages, agent_state, self.message_manager, self.actor
@@ -1261,6 +1285,7 @@ class LettaAgent(BaseAgent):
         use_bedrock_experiment: bool = False,
         step_index: int = 0,
         thinking: Optional[dict] = None,
+        thinking_config: Optional[dict] = None,
         output_config: Optional[dict] = None,
         excluded_tool_names: Optional[frozenset] = None,
     ) -> Tuple[Dict, Dict, List[Message], List[Message], List[str]] | None:
@@ -1314,6 +1339,12 @@ class LettaAgent(BaseAgent):
                 # output_config flows to all users unconditionally
                 if output_config is not None:
                     request_data["output_config"] = output_config
+                # Inject Gemini thinking_config: maps {"level": "low"|"medium"|"high"} → thinking_budget
+                if thinking_config is not None and agent_state.llm_config.model_endpoint_type in ("google_ai", "google_vertex"):
+                    level = thinking_config.get("level", "low")
+                    budget = _GEMINI_THINKING_LEVEL_TO_BUDGET.get(level, _GEMINI_THINKING_LEVEL_TO_BUDGET["low"])
+                    if "config" in request_data:
+                        request_data["config"]["thinking_config"] = {"thinking_budget": budget}
 
                 async with AsyncTimer() as timer:
                     # Attempt LLM request

--- a/letta/llm_api/google_constants.py
+++ b/letta/llm_api/google_constants.py
@@ -1,4 +1,5 @@
 GOOGLE_MODEL_TO_CONTEXT_LENGTH = {
+    "gemini-2.5-pro-preview-0506": 1048576,
     "gemini-2.5-pro-exp-03-25": 1048576,
     "gemini-2.5-flash-preview-04-17": 1048576,
     "gemini-2.0-flash-001": 1048576,
@@ -11,7 +12,7 @@ GOOGLE_MODEL_TO_CONTEXT_LENGTH = {
     "gemini-1.0-pro-vision": 16384,
 }
 
-GOOGLE_MODEL_TO_OUTPUT_LENGTH = {"gemini-2.0-flash-001": 8192, "gemini-2.5-pro-exp-03-25": 65536}
+GOOGLE_MODEL_TO_OUTPUT_LENGTH = {"gemini-2.0-flash-001": 8192, "gemini-2.5-pro-exp-03-25": 65536, "gemini-2.5-pro-preview-0506": 65536}
 
 GOOGLE_EMBEDING_MODEL_TO_DIM = {"text-embedding-005": 768, "text-multilingual-embedding-002": 768}
 

--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -60,9 +60,19 @@ class LettaRequest(BaseModel):
         description="Raw business ID from the order (1=AstroTalk, 10=Panditji, 12=Lumus). 0 when unavailable.",
     )
 
+    llm_provider: Optional[str] = Field(
+        default=None,
+        description="Override the LLM provider for this request. Use 'google' to route to Google AI (Gemini) regardless of the agent's configured endpoint.",
+    )
+
     thinking: Optional[dict] = Field(
         default=None,
         description="Extended thinking config forwarded to the Claude API (e.g. {'type': 'adaptive'}). When set, temperature is forced to 1 and max_tokens is raised to at least 8000.",
+    )
+
+    thinking_config: Optional[dict] = Field(
+        default=None,
+        description="Thinking config forwarded to Google AI / Gemini (e.g. {'level': 'low'}). Maps level ('low'|'medium'|'high') to a thinking_budget token count.",
     )
 
     output_config: Optional[dict] = Field(

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -743,9 +743,11 @@ async def send_message(
                 model_override=request.model_override,
                 user_cohort=request.user_cohort,
                 thinking=request.thinking,
+                thinking_config=request.thinking_config,
                 output_config=request.output_config,
                 task_id=request.task_id,
                 latency_optimisation_flow=request.latencyOptimisationFlow,
+                llm_provider=request.llm_provider,
             )
         else:
             result = await server.send_message_to_agent(
@@ -861,7 +863,9 @@ async def send_message_streaming(
                     model_override=request.model_override,
                     user_cohort=request.user_cohort,
                     thinking=request.thinking,
+                    thinking_config=request.thinking_config,
                     output_config=request.output_config,
+                    llm_provider=request.llm_provider,
                 ),
                 media_type="text/event-stream",
             )
@@ -878,7 +882,9 @@ async def send_message_streaming(
                     model_override=request.model_override,
                     user_cohort=request.user_cohort,
                     thinking=request.thinking,
+                    thinking_config=request.thinking_config,
                     output_config=request.output_config,
+                    llm_provider=request.llm_provider,
                 ),
                 media_type="text/event-stream",
             )


### PR DESCRIPTION
…king_config

- Add `llm_provider` and `thinking_config` fields to `LettaRequest` so callers can specify `"google"` to route a request through `GoogleAIClient` (Gemini API key mode) regardless of the agent's stored endpoint config, and supply a thinking level for Gemini 3.5 Pro/Flash.
- `_apply_provider_switching`: when `llm_provider="google"`, sets `model_endpoint_type="google_ai"` and skips Anthropic switching.
- `_build_and_request_from_llm`: injects `thinking_budget` into `request_data["config"]["thinking_config"]` for Google providers, mapping level `low→1024 / medium→8192 / high→24576` tokens.
- Thread both new params through `step`, `_step`, `step_stream_no_tokens`, `step_stream`, and the REST router.

