### PR TITLE
feat(gemini): add request logging and fix bytes serialization in telemetry

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -1346,6 +1346,16 @@ class LettaAgent(BaseAgent):
                     if "config" in request_data:
                         request_data["config"]["thinking_config"] = {"thinking_budget": budget}
 
+                if agent_state.llm_config.model_endpoint_type in ("google_ai", "google_vertex"):
+                    logger.warning(
+                        f"[GEMINI_REQUEST] at_user_id={self.at_user_id} model={agent_state.llm_config.model} "
+                        f"endpoint_type={agent_state.llm_config.model_endpoint_type} "
+                        f"thinking_config_in={thinking_config} "
+                        f"thinking_config_sent={request_data.get('config', {}).get('thinking_config')} "
+                        f"temperature={request_data.get('config', {}).get('temperature')} "
+                        f"max_output_tokens={request_data.get('config', {}).get('max_output_tokens')}"
+                    )
+
                 async with AsyncTimer() as timer:
                     # Attempt LLM request
                     response = await llm_client.request_async(request_data, agent_state.llm_config, use_vertex_experiment=use_vertex_experiment, use_bedrock_experiment=use_bedrock_experiment)

--- a/letta/helpers/json_helpers.py
+++ b/letta/helpers/json_helpers.py
@@ -10,6 +10,8 @@ def json_dumps(data, indent=2):
     def safe_serializer(obj):
         if isinstance(obj, datetime):
             return obj.isoformat()
+        if isinstance(obj, bytes):
+            return obj.decode("utf-8", errors="replace")
         raise TypeError(f"Type {type(obj)} not serializable")
 
     return json.dumps(data, indent=indent, default=safe_serializer, ensure_ascii=False)


### PR DESCRIPTION


- Log every Gemini request with at_user_id, model, endpoint_type, thinking_config sent/received, temperature, and max_output_tokens for observability in VictoriaLogs.
- Fix TypeError: Type <class 'bytes'> not serializable in json_dumps — Google genai SDK model_dump() can return bytes in the response dict; safe_serializer now decodes bytes to UTF-8 instead of crashing the entire request and failing telemetry persistence.