### PR TITLE
Reduce Azure embeddings rollout to 0% (fix archival memory 401s)

### DIFF
--- a/letta/services/passage_manager.py
+++ b/letta/services/passage_manager.py
@@ -489,7 +489,7 @@ class PassageManager:
 
         embedding_chunk_size = agent_state.embedding_config.embedding_chunk_size
 
-        # Route to Azure embeddings if GrowthBook flag is on OR userId % 10 < 6
+        # Route to Azure embeddings if GrowthBook flag is on OR userId % 10 < 0 (0% rollout)
         embedding_config = agent_state.embedding_config
         uid = gb_user_id or str(actor.id)
         use_azure = False
@@ -499,7 +499,7 @@ class PassageManager:
             use_azure = experiments_service.is_feature_on(GrowthBookFeatureKeys.USE_AZURE_EMBEDDINGS, attrs)
         if not use_azure:
             try:
-                use_azure = int(uid) % 10 < 6
+                use_azure = int(uid) % 10 < 0
             except (ValueError, TypeError):
                 pass
         if use_azure:
@@ -572,7 +572,7 @@ class PassageManager:
         if not text_chunks:
             return []
 
-        # Route to Azure embeddings via GrowthBook flag or mod10 fallback (60% rollout)
+        # Route to Azure embeddings via GrowthBook flag or mod10 fallback (0% rollout)
         embedding_config = agent_state.embedding_config
         uid = gb_user_id or str(actor.id)
         use_azure = False
@@ -582,7 +582,7 @@ class PassageManager:
             use_azure = experiments_service.is_feature_on(GrowthBookFeatureKeys.USE_AZURE_EMBEDDINGS, attrs)
         if not use_azure:
             try:
-                use_azure = int(uid) % 10 < 6
+                use_azure = int(uid) % 10 < 0
             except (ValueError, TypeError):
                 pass
         if use_azure:


### PR DESCRIPTION
## Summary
- Archival memory inserts were failing with 401 errors ("Access denied due to invalid subscription key or wrong API endpoint") for a specific agent/user, traced to the Azure OpenAI embeddings path (`EMBEDDINGS_3_SMALL_*` credentials).
- `insert_passage` / `insert_passage_async` in `letta/services/passage_manager.py` route to Azure embeddings via a GrowthBook flag (`USE_AZURE_EMBEDDINGS`) **or** a hardcoded `userId % 10 < 6` fallback (60% rollout). That fallback meant 60% of users hit Azure regardless of the flag.
- This PR drops the fallback threshold from 60% to 0% (`< 6` → `< 0`), so all archival memory embedding traffic goes through OpenAI instead, unblocking inserts while the Azure credentials are investigated/rotated separately.
- The GrowthBook `USE_AZURE_EMBEDDINGS` flag path is left intact — if that flag is explicitly on for a user, Azure is still used regardless of this rollout percentage.
- Follows the same rollout-adjustment pattern as the prior (unmerged) `azure-rollout-adjust` branch (80%→60%→30%), just carried to 0%.

## Why
Root cause is a stale/invalid Azure subscription key or endpoint mismatch for the `text-embedding-3-small` Azure deployment — not a bug in the routing logic itself. Reducing the rollout to 0% is a minimal, reversible mitigation so archival memory stops failing for the majority of users.

## Test plan
- [ ] Confirm archival memory inserts succeed for previously-affected users after deploy
- [ ] Confirm no regression in file/source ingestion embeddings (untouched by this PR)
- [ ] Once Azure credentials are fixed, decide whether to re-raise the rollout percentage or leave at 0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)