### PR TITLE
add [CHAIN_OBS] and [COST_LEAK] diagnostic logging for cost analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1027,3 +1027,8 @@ tests/test_tool_sandbox/restaurant_management_system/venv
 
 ## custom scripts
 test
+
+## claude files
+AGENTS.md
+.claude/skills/gitnexus
+.claude/commands/commit-push-pr.md

--- a/letta/agents/base_agent.py
+++ b/letta/agents/base_agent.py
@@ -156,6 +156,21 @@ class BaseAgent(ABC):
                     except Exception:
                         pass
 
+                _step_idx = getattr(self, "_current_step_index", None)
+                if _step_idx is not None and _step_idx > 0:
+                    try:
+                        import json as _json
+                        logger.warning("[COST_LEAK] %s", _json.dumps({
+                            "type": "mid_turn_rebuild",
+                            "at_user_id": _mr_at_user_id,
+                            "agent_id": agent_state.id,
+                            "step_index": _step_idx,
+                            "diff_chars": len(diff),
+                            "old_system_chars": len(curr_system_message_text),
+                        }, default=str))
+                    except Exception:
+                        pass
+
                 # Test-user-gated optimization: skip system message rewrite when
                 # the diff is small AND the total system length is unchanged. This
                 # is the signature of pure attribute-only updates (chars_current,

--- a/letta/agents/ephemeral_summary_agent.py
+++ b/letta/agents/ephemeral_summary_agent.py
@@ -7,6 +7,7 @@ from openai import AzureOpenAI
 from sqlalchemy.exc import IntegrityError
 
 from letta.agents.base_agent import BaseAgent
+from letta.debug_util import debug_log
 from letta.constants import DEFAULT_MAX_STEPS
 from letta.log import get_logger
 from letta.orm.errors import NoResultFound
@@ -134,6 +135,10 @@ class EphemeralSummaryAgent(BaseAgent):
                     messages=[{"role": "system", "content": system}] + messages,
                 )
 
+            debug_log(
+                self.at_user_id,
+                lambda _sys=system, _msgs=messages: f"summarizer AZURE FINAL_CALL model={model_settings.letta_embedding_5_4_mini_deployment} num_messages={len(_msgs)} system_chars={len(_sys)} full_body={__import__('json').dumps([{'role': 'system', 'content': _sys}] + _msgs, default=str)}",
+            )
             response = await asyncio.to_thread(_invoke)
             summary = response.choices[0].message.content.strip()
         else:
@@ -165,6 +170,10 @@ class EphemeralSummaryAgent(BaseAgent):
                     betas=["prompt-caching-2024-07-31"],
                 )
 
+            debug_log(
+                self.at_user_id,
+                lambda _sys=system, _msgs=messages: f"summarizer ANTHROPIC FINAL_CALL model=claude-haiku-4-5 num_messages={len(_msgs)} system_chars={len(_sys)} full_body={__import__('json').dumps({'system': _sys, 'messages': _msgs}, default=str)}",
+            )
             response = await asyncio.to_thread(_invoke)
             summary = response.content[0].text.strip()
 

--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -8,6 +8,7 @@ from openai.types.chat import ChatCompletionChunk
 from opentelemetry.trace import Span
 
 from letta.agents.base_agent import BaseAgent
+from letta.debug_util import debug_log
 from letta.agents.ephemeral_summary_agent import EphemeralSummaryAgent
 from letta.agents.helpers import _create_letta_response, _prepare_in_context_messages_no_persist_async, generate_step_id
 from letta.constants import DEFAULT_MAX_STEPS
@@ -345,11 +346,21 @@ class LettaAgent(BaseAgent):
         request_span = tracer.start_span("time_to_first_token", start_time=request_start_timestamp_ns)
         request_span.set_attributes({f"llm_config.{k}": v for k, v in agent_state.llm_config.model_dump().items() if v is not None})
 
+        _chain_at_uid = getattr(self, "at_user_id", None)
         for i in range(max_steps):
             step_id = generate_step_id()
             step_start = get_utc_timestamp_ns()
             agent_step_span = tracer.start_span("agent_step", start_time=step_start)
             agent_step_span.set_attributes({"step_id": step_id})
+
+            try:
+                from letta.llm_api.anthropic_client import _is_user_in_cache_obs_sample
+                import json as _json
+                if _chain_at_uid and _is_user_in_cache_obs_sample(_chain_at_uid):
+                    logger.info("[CHAIN_OBS] %s", _json.dumps({"phase": "step_start", "at_user_id": _chain_at_uid, "agent_id": agent_state.id, "step_index": i}, default=str))
+            except Exception:
+                pass
+            debug_log(self.at_user_id, f"step_stream_no_tokens: LOOP step={i}/{max_steps} agent_id={agent_state.id} model={agent_state.llm_config.model}")
 
             request_data, response_data, current_in_context_messages, new_in_context_messages, valid_tool_names = (
                 await self._build_and_request_from_llm(
@@ -464,8 +475,23 @@ class LettaAgent(BaseAgent):
 
             MetricRegistry().step_execution_time_ms_histogram.record(step_start - get_utc_timestamp_ns(), get_ctx_attributes())
 
+            if i == max_steps - 1 and should_continue:
+                try:
+                    import json as _json
+                    logger.warning("[COST_LEAK] %s", _json.dumps({"type": "max_steps_hit", "at_user_id": _chain_at_uid, "agent_id": agent_state.id, "step_count": i + 1}, default=str))
+                except Exception:
+                    pass
+
             if not should_continue:
                 break
+
+        try:
+            from letta.llm_api.anthropic_client import _is_user_in_cache_obs_sample
+            import json as _json
+            if _chain_at_uid and _is_user_in_cache_obs_sample(_chain_at_uid):
+                logger.info("[CHAIN_OBS] %s", _json.dumps({"phase": "turn_complete", "at_user_id": _chain_at_uid, "agent_id": agent_state.id, "total_steps": usage.step_count, "output_tokens": usage.completion_tokens, "input_tokens": usage.prompt_tokens}, default=str))
+        except Exception:
+            pass
 
         # Extend the in context message ids
         if not agent_state.message_buffer_autoclear:
@@ -527,7 +553,10 @@ class LettaAgent(BaseAgent):
                 f"[HAIKU_CASCADE] task_id={task_id or 'N/A'} GATED_OFF "
                 f"user_id={self.at_user_id} rollout_pct={_CASCADE_ROLLOUT_PCT} — running primary-only"
             )
+            debug_log(self.at_user_id, f"_step: cascade GATED_OFF rollout_pct={_CASCADE_ROLLOUT_PCT} → latency_optimisation_flow=False")
             latency_optimisation_flow = False
+        else:
+            debug_log(self.at_user_id, f"_step: cascade gate passed latency_optimisation_flow={latency_optimisation_flow}")
 
         _ctx_prep_start = get_utc_timestamp_ns() if task_id else None
         async with AsyncTimer() as _t:
@@ -573,6 +602,7 @@ class LettaAgent(BaseAgent):
                     f"cascade skipped (Haiku→Haiku is a no-op)"
                 )
                 MetricRegistry().haiku_cascade_request_counter.add(1, _cascade_attrs(state="disabled_primary_is_haiku"))
+                debug_log(self.at_user_id, f"_step: cascade DISABLED_PRIMARY_IS_HAIKU model={agent_state.llm_config.model}")
                 latency_optimisation_flow = False
             else:
                 _haiku_model = _HAIKU_MODEL_BY_PROVIDER.get(agent_state.llm_config.model_endpoint_type)
@@ -588,6 +618,7 @@ class LettaAgent(BaseAgent):
                         f"timeout_s={_HAIKU_TIMEOUT_SECONDS}"
                     )
                     MetricRegistry().haiku_cascade_request_counter.add(1, _cascade_attrs(state="enabled"))
+                    debug_log(self.at_user_id, f"_step: cascade ENABLED haiku_model={_haiku_model} primary_model={agent_state.llm_config.model}")
                 else:
                     logger.warning(
                         f"[HAIKU_CASCADE] task_id={task_id or 'N/A'} DISABLED_NO_MODEL "
@@ -595,6 +626,9 @@ class LettaAgent(BaseAgent):
                         f"for provider={agent_state.llm_config.model_endpoint_type}; using primary model for all steps."
                     )
                     MetricRegistry().haiku_cascade_request_counter.add(1, _cascade_attrs(state="disabled_no_model"))
+                    debug_log(self.at_user_id, f"_step: cascade DISABLED_NO_MODEL provider={agent_state.llm_config.model_endpoint_type}")
+        else:
+            debug_log(self.at_user_id, f"_step: latency_optimisation_flow=False using primary model for all steps model={agent_state.llm_config.model}")
 
         # span for request
         request_span = tracer.start_span("time_to_first_token")
@@ -618,11 +652,21 @@ class LettaAgent(BaseAgent):
         _haiku_wasted_prompt_tokens: int = 0
         _haiku_wasted_completion_tokens: int = 0
 
+        _cascade_chain_at_uid = getattr(self, "at_user_id", None)
         for i in range(max_steps):
             step_id = generate_step_id()
             step_start = get_utc_timestamp_ns()
             agent_step_span = tracer.start_span("agent_step", start_time=step_start)
             agent_step_span.set_attributes({"step_id": step_id})
+
+            try:
+                from letta.llm_api.anthropic_client import _is_user_in_cache_obs_sample
+                import json as _json
+                if _cascade_chain_at_uid and _is_user_in_cache_obs_sample(_cascade_chain_at_uid):
+                    logger.info("[CHAIN_OBS] %s", _json.dumps({"phase": "step_start", "at_user_id": _cascade_chain_at_uid, "agent_id": agent_state.id, "step_index": i}, default=str))
+            except Exception:
+                pass
+            debug_log(self.at_user_id, f"_step: LOOP step={i}/{max_steps} agent_id={agent_state.id} model={agent_state.llm_config.model}")
 
             # Cascade rule: attempt Haiku from step 1 onwards.
             #
@@ -657,15 +701,20 @@ class LettaAgent(BaseAgent):
                     f"[HAIKU_CASCADE] task_id={task_id or 'N/A'} step={i} ATTEMPT_HAIKU "
                     f"model={_original_model} -> {_haiku_model}"
                 )
+                debug_log(self.at_user_id, f"_step: step={i} ATTEMPT_HAIKU primary={_original_model} → haiku={_haiku_model}")
             elif _haiku_model and i == 0:
                 logger.warning(
                     f"[HAIKU_CASCADE] task_id={task_id or 'N/A'} step={i} KEEP_PRIMARY "
                     f"reason=step_0_always_uses_primary_to_avoid_single_step_request_tax"
                 )
                 MetricRegistry().haiku_cascade_step_counter.add(1, _cascade_attrs(outcome="primary_step0"))
+                debug_log(self.at_user_id, f"_step: step={i} KEEP_PRIMARY model={agent_state.llm_config.model}")
             elif not _haiku_model and latency_optimisation_flow:
                 # Cascade requested but no Haiku model mapped — record so we can detect misconfigs.
                 MetricRegistry().haiku_cascade_step_counter.add(1, _cascade_attrs(outcome="primary_no_haiku_model"))
+                debug_log(self.at_user_id, f"_step: step={i} no haiku model mapped using primary={agent_state.llm_config.model}")
+            else:
+                debug_log(self.at_user_id, f"_step: step={i} standard (no cascade) model={agent_state.llm_config.model}")
 
             # Strategy: gate-only (NOT tool-list restriction).
             #
@@ -726,6 +775,7 @@ class LettaAgent(BaseAgent):
             if _haiku_timed_out:
                 _haiku_timeout_step_count += 1
                 _step_used_haiku = False
+                debug_log(self.at_user_id, f"_step: step={i} HAIKU_TIMED_OUT retrying on primary model={agent_state.llm_config.model}")
                 _llm_timeout_retry_start = get_utc_timestamp_ns() if task_id else None
                 request_data, response_data, current_in_context_messages, new_in_context_messages, valid_tool_names = (
                     await self._build_and_request_from_llm(
@@ -768,6 +818,7 @@ class LettaAgent(BaseAgent):
                     _haiku_tool_call_name in _PRIMARY_RESERVED_TOOLS
                     or _haiku_tool_call_name is None
                 )
+                debug_log(self.at_user_id, f"_step: step={i} quality gate haiku_tool={_haiku_tool_call_name} needs_retry={_needs_primary_retry}")
                 if _needs_primary_retry:
                     _reason = (
                         "haiku_returned_text_response_no_tool"
@@ -816,6 +867,7 @@ class LettaAgent(BaseAgent):
                     response = llm_client.convert_response_to_chat_completion(response_data, in_context_messages, agent_state.llm_config)
                     # This step ultimately ran on the primary model, not Haiku
                     _step_used_haiku = False
+                    debug_log(self.at_user_id, lambda _i=i, _r=response: f"_step: step={_i} PRIMARY_RETRY complete tool={_r.choices[0].message.tool_calls[0].function.name if _r.choices[0].message.tool_calls else 'text'}")
 
             # TODO: add run_id
             usage.step_count += 1
@@ -954,8 +1006,30 @@ class LettaAgent(BaseAgent):
 
             MetricRegistry().step_execution_time_ms_histogram.record(step_start - get_utc_timestamp_ns(), get_ctx_attributes())
 
+            if i == max_steps - 1 and should_continue:
+                try:
+                    import json as _json
+                    logger.warning("[COST_LEAK] %s", _json.dumps({"type": "max_steps_hit", "at_user_id": _cascade_chain_at_uid, "agent_id": agent_state.id, "step_count": i + 1}, default=str))
+                except Exception:
+                    pass
+
             if not should_continue:
                 break
+
+        if _haiku_retried_step_count > 0:
+            try:
+                import json as _json
+                logger.warning("[COST_LEAK] %s", _json.dumps({"type": "haiku_cascade_retry", "at_user_id": _cascade_chain_at_uid, "agent_id": agent_state.id, "retry_count": _haiku_retried_step_count, "primary_steps": _primary_step_count, "haiku_steps": _haiku_step_count}, default=str))
+            except Exception:
+                pass
+
+        try:
+            from letta.llm_api.anthropic_client import _is_user_in_cache_obs_sample
+            import json as _json
+            if _cascade_chain_at_uid and _is_user_in_cache_obs_sample(_cascade_chain_at_uid):
+                logger.info("[CHAIN_OBS] %s", _json.dumps({"phase": "turn_complete", "at_user_id": _cascade_chain_at_uid, "agent_id": agent_state.id, "total_steps": usage.step_count, "output_tokens": usage.completion_tokens, "input_tokens": usage.prompt_tokens}, default=str))
+        except Exception:
+            pass
 
         # log request time
         if request_start_timestamp_ns:
@@ -1320,15 +1394,20 @@ class LettaAgent(BaseAgent):
                     if _filtered_tools and not _forced_call_stripped:
                         request_data["tools"] = _filtered_tools
                         valid_tool_names = [n for n in valid_tool_names if n not in excluded_tool_names]
+                        debug_log(self.at_user_id, f"_build_and_request: step={step_index} tool restriction applied excluded={excluded_tool_names} remaining={[t.get('name') for t in _filtered_tools]}")
                     else:
                         logger.warning(
                             f"[HAIKU_CASCADE] step={step_index} SKIP_TOOL_RESTRICTION "
                             f"reason={'empty_after_filter' if not _filtered_tools else 'forced_call_stripped'} "
                             f"tool_choice_name={_tc_name} — gate will handle"
                         )
+                        debug_log(self.at_user_id, f"_build_and_request: step={step_index} SKIP_TOOL_RESTRICTION reason={'empty_after_filter' if not _filtered_tools else 'forced_call_stripped'}")
+                else:
+                    debug_log(self.at_user_id, f"_build_and_request: step={step_index} no tool restriction excluded_tool_names={excluded_tool_names}")
 
                 # Inject per-request thinking overrides (gated, except Sonnet 5 which is always exempt)
                 if _thinking_override_allowed(self.at_user_id, agent_state.llm_config.model):
+                    debug_log(self.at_user_id, f"_build_and_request: step={step_index} thinking override ALLOWED model={agent_state.llm_config.model} thinking={thinking}")
                     if thinking is not None:
                         request_data["thinking"] = thinking
                         request_data["temperature"] = 1.0
@@ -1337,15 +1416,26 @@ class LettaAgent(BaseAgent):
                         # Thinking is incompatible with tool_choice "any"/"tool"; downgrade to "auto"
                         if request_data.get("tool_choice", {}).get("type") in ("any", "tool"):
                             request_data["tool_choice"] = {"type": "auto", "disable_parallel_tool_use": True}
+                        debug_log(self.at_user_id, f"_build_and_request: step={step_index} thinking injected into request_data")
+                    else:
+                        debug_log(self.at_user_id, f"_build_and_request: step={step_index} thinking override allowed but thinking=None skipping")
+                else:
+                    debug_log(self.at_user_id, f"_build_and_request: step={step_index} thinking override NOT allowed model={agent_state.llm_config.model}")
                 # output_config flows to all users unconditionally
                 if output_config is not None:
                     request_data["output_config"] = output_config
+                    debug_log(self.at_user_id, f"_build_and_request: step={step_index} output_config injected={output_config}")
+                else:
+                    debug_log(self.at_user_id, f"_build_and_request: step={step_index} output_config=None skipping")
                 # Inject Gemini thinking_config: maps {"level": "low"|"medium"|"high"} → thinking_budget
                 if thinking_config is not None and agent_state.llm_config.model_endpoint_type in ("google_ai", "google_vertex"):
                     level = thinking_config.get("level", "low")
                     budget = _GEMINI_THINKING_LEVEL_TO_BUDGET.get(level, _GEMINI_THINKING_LEVEL_TO_BUDGET["low"])
                     if "config" in request_data:
                         request_data["config"]["thinking_config"] = {"thinking_budget": budget}
+                    debug_log(self.at_user_id, f"_build_and_request: step={step_index} gemini thinking_config injected level={level} budget={budget}")
+                else:
+                    debug_log(self.at_user_id, f"_build_and_request: step={step_index} gemini thinking_config skipped thinking_config={thinking_config} endpoint_type={agent_state.llm_config.model_endpoint_type}")
 
                 if agent_state.llm_config.model_endpoint_type in ("google_ai", "google_vertex"):
                     logger.warning(
@@ -1357,6 +1447,10 @@ class LettaAgent(BaseAgent):
                         f"max_output_tokens={request_data.get('config', {}).get('max_output_tokens')}"
                     )
 
+                debug_log(
+                    self.at_user_id,
+                    lambda _si=step_index, _rd=request_data: f"_build_and_request: step={_si} FINAL_LLM_PROMPT model={agent_state.llm_config.model} endpoint_type={agent_state.llm_config.model_endpoint_type} prompt={json.dumps(_rd, default=str)}",
+                )
                 async with AsyncTimer() as timer:
                     # Attempt LLM request
                     response = await llm_client.request_async(request_data, agent_state.llm_config, use_vertex_experiment=use_vertex_experiment, use_bedrock_experiment=use_bedrock_experiment)
@@ -1485,11 +1579,14 @@ class LettaAgent(BaseAgent):
         llm_config: LLMConfig,
         force: bool,
     ) -> List[Message]:
+        debug_log(self.at_user_id, f"_handle_llm_error: error_type={type(e).__name__} is_context_window_exceeded={isinstance(e, ContextWindowExceededError)} force={force} in_context_msg_count={len(in_context_messages)}")
         if isinstance(e, ContextWindowExceededError):
+            debug_log(self.at_user_id, f"_handle_llm_error: CONTEXT_WINDOW_EXCEEDED → triggering _rebuild_context_window model={llm_config.model} context_window={llm_config.context_window}")
             return await self._rebuild_context_window(
                 in_context_messages=in_context_messages, new_letta_messages=new_letta_messages, llm_config=llm_config, force=force
             )
         else:
+            debug_log(self.at_user_id, f"_handle_llm_error: non-context-window error → re-raising error_type={type(e).__name__}")
             raise llm_client.handle_llm_error(e)
 
     @trace_method
@@ -1503,17 +1600,27 @@ class LettaAgent(BaseAgent):
     ) -> List[Message]:
         # If total tokens is reached, we truncate down
         # TODO: This can be broken by bad configs, e.g. lower bound too high, initial messages too fat, etc.
+        debug_log(self.at_user_id, f"_rebuild_context_window: entry force={force} total_tokens={total_tokens} context_window={llm_config.context_window} in_context_msg_count={len(in_context_messages)}")
         if force or (total_tokens and total_tokens > llm_config.context_window):
             self.logger.warning(
                 f"Total tokens {total_tokens} exceeds configured max tokens {llm_config.context_window}, forcefully clearing message history."
             )
+            debug_log(self.at_user_id, f"_rebuild_context_window: FORCE_CLEAR path total_tokens={total_tokens} context_window={llm_config.context_window}")
             new_in_context_messages, updated = self.summarizer.summarize(
                 in_context_messages=in_context_messages, new_letta_messages=new_letta_messages, force=True, clear=True
             )
         else:
+            debug_log(self.at_user_id, f"_rebuild_context_window: SOFT_SUMMARIZE path")
             new_in_context_messages, updated = self.summarizer.summarize(
                 in_context_messages=in_context_messages, new_letta_messages=new_letta_messages
             )
+        debug_log(self.at_user_id, f"_rebuild_context_window: summarize complete updated={updated} new_msg_count={len(new_in_context_messages)}")
+        if updated:
+            try:
+                import json as _json
+                logger.warning("[COST_LEAK] %s", _json.dumps({"type": "summarization_triggered", "at_user_id": getattr(self, "at_user_id", None), "agent_id": getattr(self, "agent_id", None)}, default=str))
+            except Exception:
+                pass
         _t_setctx = get_utc_timestamp_ns()
         await self.agent_manager.set_in_context_messages_async(
             agent_id=self.agent_id, message_ids=[m.id for m in new_in_context_messages], actor=self.actor
@@ -1559,6 +1666,16 @@ class LettaAgent(BaseAgent):
                 else asyncio.sleep(0, result=self.num_archival_memories)
             ),
         )
+
+        self._current_step_index = step_index
+        try:
+            from letta.llm_api.anthropic_client import _is_user_in_cache_obs_sample
+            import json as _json
+            _chain_uid = getattr(self, "at_user_id", None)
+            if _chain_uid and _is_user_in_cache_obs_sample(_chain_uid):
+                logger.info("[CHAIN_OBS] %s", _json.dumps({"phase": "llm_request_build", "at_user_id": _chain_uid, "agent_id": agent_state.id, "step_index": step_index, "num_messages": self.num_messages, "num_archival_memories": self.num_archival_memories}, default=str))
+        except Exception:
+            pass
 
         # PR β cascade fix: skip _rebuild_memory_async on intermediate steps of the
         # same user turn. The agent multi-step loop calls core_memory_append between
@@ -1712,6 +1829,7 @@ class LettaAgent(BaseAgent):
 
         tool_call_id = tool_call.id or f"call_{uuid.uuid4().hex[:8]}"
 
+        debug_log(self.at_user_id, f"_handle_ai_response: tool={tool_call_name} is_final_step={is_final_step} request_heartbeat={request_heartbeat} tool_valid={tool_call_name in valid_tool_names}")
         log_telemetry(
             self.logger,
             "_handle_ai_response execute tool start",
@@ -1727,6 +1845,7 @@ class LettaAgent(BaseAgent):
                 bullet_points = "\n".join(f"\t- {msg}" for msg in violated_rule_messages)
                 base_error_message += f"\n** Hint: Possible rules that were violated:\n{bullet_points}"
             tool_execution_result = ToolExecutionResult(status="error", func_return=base_error_message)
+            debug_log(self.at_user_id, f"_handle_ai_response: INVALID_TOOL tool={tool_call_name} violated_rules={violated_rule_messages}")
         else:
             async with AsyncTimer() as _t:
                 tool_execution_result = await self._execute_tool(
@@ -1740,6 +1859,7 @@ class LettaAgent(BaseAgent):
                              agent_id=agent_state.id, user_id=self.at_user_id,
                              step_id=step_id, tool=tool_call_name,
                              success=tool_execution_result.success_flag)
+            debug_log(self.at_user_id, f"_handle_ai_response: tool_executed tool={tool_call_name} success={tool_execution_result.success_flag} elapsed_ms={_t.elapsed_ms:.0f}")
         log_telemetry(
             self.logger, "_handle_ai_response execute tool finish", tool_execution_result=tool_execution_result, tool_call_id=tool_call_id
         )
@@ -1747,10 +1867,12 @@ class LettaAgent(BaseAgent):
         if tool_call_name in ["conversation_search", "conversation_search_date", "archival_memory_search"]:
             # with certain functions we rely on the paging mechanism to handle overflow
             truncate = False
+            debug_log(self.at_user_id, f"_handle_ai_response: MEMORY_SEARCH tool={tool_call_name} truncate=False (paging mode)")
         else:
             # but by default, we add a truncation safeguard to prevent bad functions from
             # overflow the agent context window
             truncate = True
+            debug_log(self.at_user_id, f"_handle_ai_response: tool={tool_call_name} truncate=True")
 
         # get the function response limit
         target_tool = next((x for x in agent_state.tools if x.name == tool_call_name), None)
@@ -1771,10 +1893,15 @@ class LettaAgent(BaseAgent):
             if continue_stepping:
                 stop_reason = LettaStopReason(stop_reason=StopReasonType.tool_rule.value)
             continue_stepping = False
+            debug_log(self.at_user_id, f"_handle_ai_response: TERMINAL_TOOL tool={tool_call_name} continue_stepping=False stop_reason={stop_reason}")
         elif tool_rules_solver.has_children_tools(tool_name=tool_call_name):
             continue_stepping = True
+            debug_log(self.at_user_id, f"_handle_ai_response: HAS_CHILDREN_TOOLS tool={tool_call_name} continue_stepping=True")
         elif tool_rules_solver.is_continue_tool(tool_name=tool_call_name):
             continue_stepping = True
+            debug_log(self.at_user_id, f"_handle_ai_response: CONTINUE_TOOL tool={tool_call_name} continue_stepping=True")
+        else:
+            debug_log(self.at_user_id, f"_handle_ai_response: tool={tool_call_name} continue_stepping={continue_stepping} (request_heartbeat)")
 
         # 5a. Persist Steps to DB
         # Following agent loop to persist this before messages
@@ -1876,6 +2003,9 @@ class LettaAgent(BaseAgent):
             actor=self.actor,
         )
         # TODO: Integrate sandbox result
+        _is_archival = tool_name in ("archival_memory_insert", "archival_memory_search", "archival_memory_delete")
+        if _is_archival:
+            debug_log(self.at_user_id, lambda _n=tool_name, _a=tool_args: f"_execute_tool: ARCHIVAL_MEMORY tool={_n} args={__import__('json').dumps(_a, default=str)}")
         log_event(name=f"start_{tool_name}_execution", attributes=tool_args)
         tool_execution_result = await tool_execution_manager.execute_tool_async(
             function_name=tool_name,
@@ -1883,6 +2013,8 @@ class LettaAgent(BaseAgent):
             tool=target_tool,
             step_id=step_id,
         )
+        if _is_archival:
+            debug_log(self.at_user_id, lambda _n=tool_name, _r=tool_execution_result: f"_execute_tool: ARCHIVAL_MEMORY_RESULT tool={_n} success={_r.success_flag} result={__import__('json').dumps(_r.func_return, default=str)}")
         if agent_step_span:
             end_time = get_utc_timestamp_ns()
             agent_step_span.add_event(

--- a/letta/debug_util.py
+++ b/letta/debug_util.py
@@ -1,0 +1,54 @@
+import uuid
+from contextvars import ContextVar
+from typing import Callable, Union
+
+from letta.log import get_logger
+
+logger = get_logger(__name__)
+_DEBUG_USER_ID = "125526285"
+
+# Holds a per-request trace ID set at send_message entry.
+# Automatically propagated to asyncio tasks via contextvars semantics.
+_debug_request_id: ContextVar[str] = ContextVar("debug_request_id", default="")
+
+
+def set_debug_request_id(user_id, request_id: str) -> None:
+    """Set a request ID — no-op for any user other than the debug user."""
+    try:
+        if str(user_id) == _DEBUG_USER_ID:
+            _debug_request_id.set(request_id)
+    except Exception:
+        pass
+
+
+def new_debug_request_id(user_id) -> str:
+    """Generate and set a short request ID. No-op (returns '') for non-debug users."""
+    try:
+        if str(user_id) == _DEBUG_USER_ID:
+            rid = uuid.uuid4().hex[:12]
+            _debug_request_id.set(rid)
+            return rid
+    except Exception:
+        pass
+    return ""
+
+
+def debug_log(user_id, message: Union[str, Callable[[], str]]) -> None:
+    """Log a debug message only for the hardcoded debug user.
+
+    Pass a callable (lambda) when the message involves expensive computation
+    (e.g. json.dumps on large payloads) — it is only evaluated if the user
+    matches, and any exception during evaluation or logging is silently swallowed
+    so this never causes a regression in the calling code.
+
+    Every log line is automatically prefixed with the current request ID so all
+    logs from one end-to-end request can be correlated by filtering on that ID.
+    """
+    try:
+        if str(user_id) == _DEBUG_USER_ID:
+            msg = message() if callable(message) else message
+            rid = _debug_request_id.get()
+            prefix = f"[req={rid}] " if rid else ""
+            logger.info("[DEBUG_USER] %s%s", prefix, msg)
+    except Exception:
+        pass

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -27,6 +27,7 @@ from letta.errors import (
 from letta.helpers.datetime_helpers import get_utc_time_int
 from letta.llm_api.bedrock_inference_profiles import COHORT_INFERENCE_PROFILES, MODEL_INFERENCE_PROFILES
 from letta.llm_api.helpers import add_inner_thoughts_to_functions, unpack_all_inner_thoughts_from_kwargs
+from letta.debug_util import _DEBUG_USER_ID, debug_log
 from letta.llm_api.llm_client_base import LLMClientBase
 from letta.local_llm.constants import INNER_THOUGHTS_KWARG, INNER_THOUGHTS_KWARG_DESCRIPTION
 from letta.log import get_logger
@@ -47,7 +48,7 @@ DUMMY_FIRST_USER_MESSAGE = "User initializing bootup sequence."
 # observed (force-included regardless of sampling). Empty string disables the
 # always-on user. The v2 cache-optimization path is controlled by the
 # V2_CACHE_ROLLOUT_* knobs below, not by this constant.
-CACHE_OBS_USER_ID = "92744418"
+CACHE_OBS_USER_ID = _DEBUG_USER_ID
 
 # Broader sampling for cache-observability logs across all v2 traffic.
 # Percentage of users whose (int(at_user_id) % 100) < CACHE_OBS_SAMPLE_PCT
@@ -56,7 +57,7 @@ CACHE_OBS_USER_ID = "92744418"
 # At 1%, on ~22k calls/hour we expect ~220 sampled calls/hour = manageable
 # log volume. We need this to determine the dominant cache-invalidation
 # source in aggregate production traffic (not just one user).
-CACHE_OBS_SAMPLE_PCT = 5
+CACHE_OBS_SAMPLE_PCT = 1
 
 # Cold-miss threshold for CACHE_MISS_DIAG: emit diagnostic only when
 # cache_read == 0 AND cache_creation > this many tokens. Filters out tiny
@@ -187,7 +188,10 @@ class AnthropicClient(LLMClientBase):
     async def request_async(self, request_data: dict, llm_config: LLMConfig, use_vertex_experiment: bool = False, use_bedrock_experiment: bool = False) -> dict:
         # Check if we should use Vertex AI based on model_endpoint_type
         # (This happens when use_vertex_experiment changes the endpoint type in _step)
+        _at_uid = getattr(self, "at_user_id", None)
+        debug_log(_at_uid, f"request_async: endpoint_type={llm_config.model_endpoint_type} model={llm_config.model} use_vertex={use_vertex_experiment} use_bedrock={use_bedrock_experiment}")
         if llm_config.model_endpoint_type == "anthropic_vertex":
+            debug_log(_at_uid, f"request_async: VERTEX branch project={model_settings.google_cloud_project}")
             from anthropic import AsyncAnthropicVertex
             from letta.settings import model_settings
             import os
@@ -218,8 +222,10 @@ class AnthropicClient(LLMClientBase):
                     _vertex_extra_body["output_config"] = v
                 else:
                     _vertex_sdk_data[k] = v
+            debug_log(_at_uid, f"request_async: VERTEX FINAL_CALL model={_vertex_sdk_data.get('model')} region={region} extra_body={bool(_vertex_extra_body)} num_messages={len(_vertex_sdk_data.get('messages', []))} num_tools={len(_vertex_sdk_data.get('tools', []))}")
             response = await client.messages.create(**_vertex_sdk_data, **({"extra_body": _vertex_extra_body} if _vertex_extra_body else {}))
         elif llm_config.model_endpoint_type == "anthropic_bedrock":
+            debug_log(_at_uid, f"request_async: BEDROCK branch model={llm_config.model}")
             import os
             import json
             import asyncio
@@ -249,6 +255,7 @@ class AnthropicClient(LLMClientBase):
             if requested_model_raw.startswith(_BEDROCK_DIRECT_PREFIXES):
                 # Full ARN or system inference profile ID — use verbatim, skip env-var lookup.
                 bedrock_inference_profile = requested_model_raw
+                debug_log(_at_uid, f"request_async: BEDROCK model resolution DIRECT_ARN bedrock_inference_profile={bedrock_inference_profile}")
             else:
                 cohort_arn = _resolve_bedrock_arn_from_cohort(
                     getattr(self, "at_user_id", None),
@@ -256,17 +263,23 @@ class AnthropicClient(LLMClientBase):
                 )
                 if cohort_arn:
                     bedrock_inference_profile = cohort_arn
+                    debug_log(_at_uid, f"request_async: BEDROCK model resolution COHORT_ARN bedrock_inference_profile={bedrock_inference_profile}")
                 else:
                     default_arn = os.getenv('BEDROCK_INFERENCE_PROFILE_ARN')
                     if "haiku" in requested_model:
                         bedrock_inference_profile = os.getenv('BEDROCK_HAIKU_INFERENCE_PROFILE_ARN') or default_arn
+                        debug_log(_at_uid, f"request_async: BEDROCK model resolution HAIKU bedrock_inference_profile={bedrock_inference_profile}")
                     elif "sonnet-4-6" in requested_model or "sonnet-4.6" in requested_model:
                         bedrock_inference_profile = os.getenv('BEDROCK_SONNET_4_6_INFERENCE_PROFILE_ARN') or default_arn
+                        debug_log(_at_uid, f"request_async: BEDROCK model resolution SONNET_4_6 bedrock_inference_profile={bedrock_inference_profile}")
                     elif "sonnet-5" in requested_model:
                         bedrock_inference_profile = _build_bedrock_arn(MODEL_INFERENCE_PROFILES["sonnet-5"])
+                        debug_log(_at_uid, f"request_async: BEDROCK model resolution SONNET_5 bedrock_inference_profile={bedrock_inference_profile}")
                     else:
                         bedrock_inference_profile = default_arn
+                        debug_log(_at_uid, f"request_async: BEDROCK model resolution DEFAULT bedrock_inference_profile={bedrock_inference_profile}")
             model_id = bedrock_inference_profile if bedrock_inference_profile else request_data.get('model')
+            debug_log(_at_uid, f"request_async: BEDROCK resolved model_id={model_id} aws_region={aws_region}")
 
             client_kwargs = {
                 "service_name": "bedrock-runtime",
@@ -335,6 +348,7 @@ class AnthropicClient(LLMClientBase):
                 len(bedrock_body.get("tools", [])),
             )
 
+            debug_log(_at_uid, lambda: f"request_async: BEDROCK FINAL_CALL model_id={model_id} num_messages={len(bedrock_body.get('messages', []))} num_tools={len(bedrock_body.get('tools', []))} thinking={bedrock_body.get('thinking')} max_tokens={bedrock_body.get('max_tokens')} tool_choice={bedrock_body.get('tool_choice')} full_body={json.dumps(bedrock_body, default=str)}")
             # Run synchronous boto3 call in a thread to avoid blocking the event loop
             def _invoke():
                 resp = bedrock_client.invoke_model(
@@ -365,8 +379,10 @@ class AnthropicClient(LLMClientBase):
                 endpoint_type=llm_config.model_endpoint_type,
                 model=request_data.get("model"),
             )
+            debug_log(_at_uid, lambda _r=response_dict: f"request_async: BEDROCK LLM_RESPONSE body={json.dumps(_r, default=str)}")
             return response_dict
         else:
+            debug_log(_at_uid, f"request_async: STANDARD_ANTHROPIC branch model={llm_config.model}")
             client = await self._get_anthropic_client_async(llm_config, async_client=True)
             _extra_body = {}
             _sdk_data = {}
@@ -375,6 +391,7 @@ class AnthropicClient(LLMClientBase):
                     _extra_body["output_config"] = v
                 else:
                     _sdk_data[k] = v
+            debug_log(_at_uid, lambda: f"request_async: STANDARD_ANTHROPIC FINAL_CALL model={_sdk_data.get('model')} num_messages={len(_sdk_data.get('messages', []))} num_tools={len(_sdk_data.get('tools', []))} thinking={_sdk_data.get('thinking')} max_tokens={_sdk_data.get('max_tokens')} tool_choice={_sdk_data.get('tool_choice')} full_body={json.dumps(_sdk_data, default=str)}")
             response = await client.beta.messages.create(**_sdk_data, betas=["tools-2024-04-04", "prompt-caching-2024-07-31"], **({"extra_body": _extra_body} if _extra_body else {}))
         logger.info("This is the usage response from claude %s", response.usage)
         self._log_cache_observation_usage(
@@ -382,6 +399,7 @@ class AnthropicClient(LLMClientBase):
             endpoint_type=llm_config.model_endpoint_type,
             model=request_data.get("model"),
         )
+        debug_log(_at_uid, lambda _r=response: f"request_async: LLM_RESPONSE body={json.dumps(_r.model_dump(), default=str)}")
         return response.model_dump()
 
     @trace_method

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError
 from starlette.responses import Response, StreamingResponse
 
 from letta.agents.letta_agent import LettaAgent
+from letta.debug_util import debug_log, new_debug_request_id
 from letta.constants import DEFAULT_MAX_STEPS, DEFAULT_MESSAGE_TOOL, DEFAULT_MESSAGE_TOOL_KWARG
 from letta.groups.sleeptime_multi_agent_v2 import SleeptimeMultiAgentV2
 from letta.helpers.datetime_helpers import get_utc_timestamp_ns, ns_to_ms
@@ -237,11 +238,16 @@ async def create_agent(
     server: "SyncServer" = Depends(get_letta_server),
     actor_id: Optional[str] = Header(None, alias="user_id"),  # Extract user_id from header, default to None if not present
     x_project: Optional[str] = Header(None, alias="X-Project"),  # Only handled by next js middleware
+    at_user_id: Optional[str] = Header(None, alias="x_gb_user_id"),
 ):
     """
     Create a new agent with the specified configuration.
     """
     try:
+        debug_log(
+            at_user_id,
+            lambda: f"[CREATE_AGENT_REQ] at_user_id={at_user_id} actor_id={actor_id} body={__import__('json').dumps(agent.model_dump(mode='json'), default=str)}",
+        )
         actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
         return await server.create_agent_async(agent, actor=actor)
     except Exception as e:
@@ -566,6 +572,25 @@ async def create_passage(
     Insert a memory into an agent's archival memory store.
     """
     actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
+    try:
+        from letta.llm_api.anthropic_client import _is_user_in_cache_obs_sample
+        import json as _json
+
+        if _is_user_in_cache_obs_sample(gb_user_id):
+            logger.info(
+                "[CHAIN_OBS] %s",
+                _json.dumps(
+                    {
+                        "phase": "archival_create",
+                        "at_user_id": gb_user_id,
+                        "agent_id": agent_id,
+                        "text_len": len(request.text),
+                    },
+                    default=str,
+                ),
+            )
+    except Exception:
+        pass
     return await server.insert_archival_memory_async(agent_id=agent_id, memory_contents=request.text, actor=actor, gb_user_id=gb_user_id)
 
 
@@ -676,6 +701,7 @@ async def send_message(
     """
     request_start_timestamp_ns = get_utc_timestamp_ns()
     MetricRegistry().user_message_counter.add(1, get_ctx_attributes())
+    new_debug_request_id(at_user_id)
 
     # Tag the OTel request context with the flow flag so it propagates DOWN into
     # the agent loop and labels every nested metric (step / llm / ttft / tokens /
@@ -685,7 +711,31 @@ async def send_message(
     _lof_attr = str(bool(request.latencyOptimisationFlow)).lower()
     add_ctx_attribute("latency_optimisation_flow", _lof_attr)
 
-    logger.warning(f"[SEND_MESSAGE] use_vertex_experiment={request.use_vertex_experiment}, use_bedrock_experiment={request.use_bedrock_experiment}, model_override={request.model_override}, llm_provider={request.llm_provider}")
+    logger.warning(
+        f"[SEND_MESSAGE] use_vertex_experiment={request.use_vertex_experiment}, use_bedrock_experiment={request.use_bedrock_experiment}, model_override={request.model_override}, llm_provider={request.llm_provider}"
+    )
+
+    try:
+        from letta.llm_api.anthropic_client import _is_user_in_cache_obs_sample
+        import json as _json
+
+        if _is_user_in_cache_obs_sample(at_user_id):
+            logger.info(
+                "[CHAIN_OBS] %s",
+                _json.dumps(
+                    {
+                        "phase": "send_message_entry",
+                        "at_user_id": at_user_id,
+                        "agent_id": agent_id,
+                        "message_count": len(request.messages),
+                        "model_override": request.model_override,
+                        "llm_provider": request.llm_provider,
+                    },
+                    default=str,
+                ),
+            )
+    except Exception:
+        pass
 
     # Headline end-to-end latency for the two flows, recorded here (not the ASGI
     # middleware) because the flag is only known inside the handler.
@@ -697,17 +747,24 @@ async def send_message(
         _t_agent = get_utc_timestamp_ns()
         agent = await server.agent_manager.get_agent_by_id_async(agent_id, actor, include_relationships=["multi_agent_group"])
         if request.task_id:
-            logger.warning(
-                f"[TASK_LATENCY] task_id={request.task_id} phase=actor_load duration_ms={ns_to_ms(_t_agent - _t_actor)}"
-            )
+            logger.warning(f"[TASK_LATENCY] task_id={request.task_id} phase=actor_load duration_ms={ns_to_ms(_t_agent - _t_actor)}")
             logger.warning(
                 f"[TASK_LATENCY] task_id={request.task_id} phase=agent_load duration_ms={ns_to_ms(get_utc_timestamp_ns() - _t_agent)}"
             )
         agent_eligible = agent.multi_agent_group is None or agent.multi_agent_group.manager_type in ["sleeptime", "voice_sleeptime"]
         model_compatible = agent.llm_config.model_endpoint_type in ["anthropic", "openai", "together", "google_ai", "google_vertex"]
+        debug_log(
+            at_user_id,
+            f"send_message branch: agent_eligible={agent_eligible} model_compatible={model_compatible} endpoint_type={agent.llm_config.model_endpoint_type}",
+        )
 
         if agent_eligible and model_compatible:
+            debug_log(
+                at_user_id,
+                f"send_message: using new agent loop path enable_sleeptime={agent.enable_sleeptime} agent_type={agent.agent_type}",
+            )
             if agent.enable_sleeptime and agent.agent_type != AgentType.voice_convo_agent:
+                debug_log(at_user_id, "send_message: choosing SleeptimeMultiAgentV2")
                 agent_loop = SleeptimeMultiAgentV2(
                     agent_id=agent_id,
                     message_manager=server.message_manager,
@@ -720,6 +777,7 @@ async def send_message(
                     group=agent.multi_agent_group,
                 )
             else:
+                debug_log(at_user_id, "send_message: choosing LettaAgent")
                 agent_loop = LettaAgent(
                     agent_id=agent_id,
                     message_manager=server.message_manager,
@@ -750,6 +808,10 @@ async def send_message(
                 llm_provider=request.llm_provider,
             )
         else:
+            debug_log(
+                at_user_id,
+                f"send_message: falling back to legacy send_message_to_agent agent_eligible={agent_eligible} model_compatible={model_compatible}",
+            )
             result = await server.send_message_to_agent(
                 agent_id=agent_id,
                 actor=actor,
@@ -810,8 +872,9 @@ async def send_message_streaming(
     request_start_timestamp_ns = get_utc_timestamp_ns()
     MetricRegistry().user_message_counter.add(1, get_ctx_attributes())
 
-    logger.warning(f"[SEND_MESSAGE_STREAMING] use_vertex_experiment={request.use_vertex_experiment}, use_bedrock_experiment={request.use_bedrock_experiment}, model_override={request.model_override}, llm_provider={request.llm_provider}")
-
+    logger.warning(
+        f"[SEND_MESSAGE_STREAMING] use_vertex_experiment={request.use_vertex_experiment}, use_bedrock_experiment={request.use_bedrock_experiment}, model_override={request.model_override}, llm_provider={request.llm_provider}"
+    )
 
     actor = await server.user_manager.get_actor_or_default_async(actor_id=actor_id)
     # TODO: This is redundant, remove soon

--- a/letta/services/tool_executor/core_tool_executor.py
+++ b/letta/services/tool_executor/core_tool_executor.py
@@ -1,6 +1,10 @@
 import math
 from typing import Any, Dict, Optional
 
+from letta.log import get_logger
+
+logger = get_logger(__name__)
+
 from letta.constants import (
     CORE_MEMORY_LINE_NUMBER_WARNING,
     MEMORY_TOOLS_LINE_NUMBER_PREFIX_REGEX,
@@ -200,6 +204,11 @@ class LettaCoreToolExecutor(ToolExecutor):
         new_value = current_value + "\n" + str(content)
         agent_state.memory.update_block_value(label=label, value=new_value)
         await AgentManager().update_memory_if_changed_async(agent_id=agent_state.id, new_memory=agent_state.memory, actor=actor)
+        try:
+            import json as _json
+            logger.warning("[COST_LEAK] %s", _json.dumps({"type": "tool_executor_rebuild", "tool": "core_memory_append", "agent_id": agent_state.id}, default=str))
+        except Exception:
+            pass
         return None
 
     async def core_memory_replace(
@@ -229,6 +238,11 @@ class LettaCoreToolExecutor(ToolExecutor):
         new_value = current_value.replace(str(old_content), str(new_content))
         agent_state.memory.update_block_value(label=label, value=new_value)
         await AgentManager().update_memory_if_changed_async(agent_id=agent_state.id, new_memory=agent_state.memory, actor=actor)
+        try:
+            import json as _json
+            logger.warning("[COST_LEAK] %s", _json.dumps({"type": "tool_executor_rebuild", "tool": "core_memory_replace", "agent_id": agent_state.id}, default=str))
+        except Exception:
+            pass
         return None
 
     async def memory_replace(


### PR DESCRIPTION
## Summary

- Reduces `CACHE_OBS_SAMPLE_PCT` 5→1 so all existing cache-obs logs drop to 1% sampling
- Adds `[CHAIN_OBS]` trace logs (1% user-level, deterministic by `at_user_id % 100`) at: `send_message` entry, `POST /archival-memory` entry, per agent loop step, and `_create_llm_request_data_async`
- Adds `[COST_LEAK]` always-on anomaly logs for every known cost-amplifying event:
  - `tool_executor_rebuild` — fires after `core_memory_append` / `core_memory_replace`, the root cause of cascade cache invalidation
  - `mid_turn_rebuild` — fires in `_rebuild_memory_async` when memory changes at `step_index > 0`
  - `max_steps_hit` — agent exhausted `max_steps` with `should_continue=true`
  - `haiku_cascade_retry` — haiku quality gate fired and retried on primary model
  - `summarization_triggered` — context window summarizer fired
- Sets `self._current_step_index` in `_create_llm_request_data_async` so rebuild detection has step context
- Gitignores `.claude/` skills and commands dirs