### PR TITLE
cache obs / debug_log tweaks

### DIFF
--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -104,8 +104,8 @@ def _is_user_in_v2_cache_bucket(at_user_id):
     # missing/non-numeric ids so unknown traffic defaults to the v1 path (fail-closed).
     if not at_user_id:
         return False
-    if CACHE_OBS_USER_ID and at_user_id == CACHE_OBS_USER_ID:
-        return True
+    # if CACHE_OBS_USER_ID and at_user_id == CACHE_OBS_USER_ID:
+    #     return True
     if V2_CACHE_ROLLOUT_BUCKET_MAX <= 0:
         return False
     if V2_CACHE_ROLLOUT_BUCKET_MAX >= V2_CACHE_ROLLOUT_MOD:


### PR DESCRIPTION
## Summary

- Comments out the \`CACHE_OBS_USER_ID\` force-include check in \`_is_user_in_v2_cache_bucket\` so the test user is no longer pinned to the v2 cache layout
- The bypass in \`_is_user_in_cache_obs_sample\` remains active so the test user still appears in cache obs logs
- Adds \`user_id=<id>\` to every \`[DEBUG_USER]\` log line emitted by \`debug_log\`