### PR TITLE
add [EMBEDDING_SEARCH] latency logs to passage search methods

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -2001,6 +2001,7 @@ class LettaAgent(BaseAgent):
             passage_manager=self.passage_manager,
             sandbox_env_vars=sandbox_env_vars,
             actor=self.actor,
+            task_id=self._task_id,
         )
         # TODO: Integrate sandbox result
         _is_archival = tool_name in ("archival_memory_insert", "archival_memory_search", "archival_memory_delete")

--- a/letta/agents/voice_agent.py
+++ b/letta/agents/voice_agent.py
@@ -468,6 +468,7 @@ class VoiceAgent(BaseAgent):
             embed_query=True,
             start_date=start_date,
             end_date=end_date,
+            task_id=self._task_id,
         )
         formatted_archival_results = [{"timestamp": str(result.created_at), "content": result.text} for result in archival_results]
         response = {

--- a/letta/services/agent_manager.py
+++ b/letta/services/agent_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -19,7 +20,7 @@ from letta.constants import (
     MULTI_AGENT_TOOLS,
 )
 from letta.helpers import ToolRulesSolver
-from letta.helpers.datetime_helpers import get_utc_time
+from letta.helpers.datetime_helpers import AsyncTimer, get_utc_time
 from letta.llm_api.llm_client import LLMClient
 from letta.log import get_logger
 from letta.orm import Agent as AgentModel
@@ -2054,9 +2055,11 @@ class AgentManager:
         ascending: bool = True,
         embedding_config: Optional[EmbeddingConfig] = None,
         agent_only: bool = False,
+        task_id: Optional[str] = None,
     ) -> List[PydanticPassage]:
         """Lists all passages attached to an agent."""
         with db_registry.session() as session:
+            _t0 = time.perf_counter()
             main_query = build_passage_query(
                 actor=actor,
                 agent_id=agent_id,
@@ -2072,13 +2075,15 @@ class AgentManager:
                 embedding_config=embedding_config,
                 agent_only=agent_only,
             )
+            _embed_ms = (time.perf_counter() - _t0) * 1000
 
             # Add limit
             if limit:
                 main_query = main_query.limit(limit)
 
-            # Execute query
+            _t1 = time.perf_counter()
             results = list(session.execute(main_query))
+            _query_ms = (time.perf_counter() - _t1) * 1000
 
             passages = []
             for row in results:
@@ -2094,6 +2099,27 @@ class AgentManager:
                     data.pop("agent_id", None)
                     passage = SourcePassage(**data)
                 passages.append(passage)
+
+            if task_id:
+                logger.info(
+                    "[EMBEDDING_SEARCH] fn=list_passages  phase=embed  embed_query=%s  elapsed_ms=%.0f  agent_id=%s  user_id=%s  task_id=%s  limit=%s",
+                    embed_query,
+                    _embed_ms,
+                    agent_id,
+                    actor.id,
+                    task_id,
+                    limit,
+                )
+                logger.info(
+                    "[EMBEDDING_SEARCH] fn=list_passages  phase=db_query  embed_query=%s  elapsed_ms=%.0f  agent_id=%s  user_id=%s  task_id=%s  limit=%s  result_count=%d",
+                    embed_query,
+                    _query_ms,
+                    agent_id,
+                    actor.id,
+                    task_id,
+                    limit,
+                    len(passages),
+                )
 
             return [p.to_pydantic() for p in passages]
 
@@ -2115,9 +2141,11 @@ class AgentManager:
         ascending: bool = True,
         embedding_config: Optional[EmbeddingConfig] = None,
         agent_only: bool = False,
+        task_id: Optional[str] = None,
     ) -> List[PydanticPassage]:
         """Lists all passages attached to an agent."""
         async with db_registry.async_session() as session:
+            _t0 = time.perf_counter()
             main_query = build_passage_query(
                 actor=actor,
                 agent_id=agent_id,
@@ -2133,13 +2161,14 @@ class AgentManager:
                 embedding_config=embedding_config,
                 agent_only=agent_only,
             )
+            _embed_ms = (time.perf_counter() - _t0) * 1000
 
             # Add limit
             if limit:
                 main_query = main_query.limit(limit)
 
-            # Execute query
-            result = await session.execute(main_query)
+            async with AsyncTimer() as _t:
+                result = await session.execute(main_query)
 
             passages = []
             for row in result:
@@ -2155,6 +2184,27 @@ class AgentManager:
                     data.pop("agent_id", None)
                     passage = SourcePassage(**data)
                 passages.append(passage)
+
+            if task_id:
+                logger.info(
+                    "[EMBEDDING_SEARCH] fn=list_passages_async  phase=embed  embed_query=%s  elapsed_ms=%.0f  agent_id=%s  user_id=%s  task_id=%s  limit=%s",
+                    embed_query,
+                    _embed_ms,
+                    agent_id,
+                    actor.id,
+                    task_id,
+                    limit,
+                )
+                logger.info(
+                    "[EMBEDDING_SEARCH] fn=list_passages_async  phase=db_query  embed_query=%s  elapsed_ms=%.0f  agent_id=%s  user_id=%s  task_id=%s  limit=%s  result_count=%d",
+                    embed_query,
+                    _t.elapsed_ms,
+                    agent_id,
+                    actor.id,
+                    task_id,
+                    limit,
+                    len(passages),
+                )
 
             return [p.to_pydantic() for p in passages]
 
@@ -2175,9 +2225,11 @@ class AgentManager:
         embed_query: bool = False,
         ascending: bool = True,
         embedding_config: Optional[EmbeddingConfig] = None,
+        task_id: Optional[str] = None,
     ) -> List[PydanticPassage]:
         """Lists all passages attached to an agent."""
         async with db_registry.async_session() as session:
+            _t0 = time.perf_counter()
             main_query = build_source_passage_query(
                 actor=actor,
                 agent_id=agent_id,
@@ -2192,16 +2244,38 @@ class AgentManager:
                 ascending=ascending,
                 embedding_config=embedding_config,
             )
+            _embed_ms = (time.perf_counter() - _t0) * 1000
 
             # Add limit
             if limit:
                 main_query = main_query.limit(limit)
 
-            # Execute query
-            result = await session.execute(main_query)
+            async with AsyncTimer() as _t:
+                result = await session.execute(main_query)
 
             # Get ORM objects directly using scalars()
             passages = result.scalars().all()
+
+            if task_id:
+                logger.info(
+                    "[EMBEDDING_SEARCH] fn=list_source_passages_async  phase=embed  embed_query=%s  elapsed_ms=%.0f  agent_id=%s  user_id=%s  task_id=%s  limit=%s",
+                    embed_query,
+                    _embed_ms,
+                    agent_id,
+                    actor.id,
+                    task_id,
+                    limit,
+                )
+                logger.info(
+                    "[EMBEDDING_SEARCH] fn=list_source_passages_async  phase=db_query  embed_query=%s  elapsed_ms=%.0f  agent_id=%s  user_id=%s  task_id=%s  limit=%s  result_count=%d",
+                    embed_query,
+                    _t.elapsed_ms,
+                    agent_id,
+                    actor.id,
+                    task_id,
+                    limit,
+                    len(passages),
+                )
 
             # Convert to Pydantic models
             return [p.to_pydantic() for p in passages]
@@ -2221,9 +2295,11 @@ class AgentManager:
         embed_query: bool = False,
         ascending: bool = True,
         embedding_config: Optional[EmbeddingConfig] = None,
+        task_id: Optional[str] = None,
     ) -> List[PydanticPassage]:
         """Lists all passages attached to an agent."""
         async with db_registry.async_session() as session:
+            _t0 = time.perf_counter()
             main_query = build_agent_passage_query(
                 actor=actor,
                 agent_id=agent_id,
@@ -2236,16 +2312,38 @@ class AgentManager:
                 ascending=ascending,
                 embedding_config=embedding_config,
             )
+            _embed_ms = (time.perf_counter() - _t0) * 1000
 
             # Add limit
             if limit:
                 main_query = main_query.limit(limit)
 
-            # Execute query
-            result = await session.execute(main_query)
+            async with AsyncTimer() as _t:
+                result = await session.execute(main_query)
 
             # Get ORM objects directly using scalars()
             passages = result.scalars().all()
+
+            if task_id:
+                logger.info(
+                    "[EMBEDDING_SEARCH] fn=list_agent_passages_async  phase=embed  embed_query=%s  elapsed_ms=%.0f  agent_id=%s  user_id=%s  task_id=%s  limit=%s",
+                    embed_query,
+                    _embed_ms,
+                    agent_id,
+                    actor.id,
+                    task_id,
+                    limit,
+                )
+                logger.info(
+                    "[EMBEDDING_SEARCH] fn=list_agent_passages_async  phase=db_query  embed_query=%s  elapsed_ms=%.0f  agent_id=%s  user_id=%s  task_id=%s  limit=%s  result_count=%d",
+                    embed_query,
+                    _t.elapsed_ms,
+                    agent_id,
+                    actor.id,
+                    task_id,
+                    limit,
+                    len(passages),
+                )
 
             # Convert to Pydantic models
             return [p.to_pydantic() for p in passages]

--- a/letta/services/tool_executor/core_tool_executor.py
+++ b/letta/services/tool_executor/core_tool_executor.py
@@ -154,6 +154,7 @@ class LettaCoreToolExecutor(ToolExecutor):
                 limit=count + start,  # Request enough results to handle offset
                 embedding_config=agent_state.embedding_config,
                 embed_query=True,
+                task_id=self.task_id,
             )
 
             # Apply pagination

--- a/letta/services/tool_executor/tool_execution_manager.py
+++ b/letta/services/tool_executor/tool_execution_manager.py
@@ -51,6 +51,7 @@ class ToolExecutorFactory:
         block_manager: BlockManager,
         passage_manager: PassageManager,
         actor: User,
+        task_id: Optional[str] = None,
     ) -> ToolExecutor:
         """Get the appropriate executor for the given tool type."""
         executor_class = cls._executor_map.get(tool_type, SandboxToolExecutor)
@@ -60,6 +61,7 @@ class ToolExecutorFactory:
             block_manager=block_manager,
             passage_manager=passage_manager,
             actor=actor,
+            task_id=task_id,
         )
 
 
@@ -76,6 +78,7 @@ class ToolExecutionManager:
         agent_state: Optional[AgentState] = None,
         sandbox_config: Optional[SandboxConfig] = None,
         sandbox_env_vars: Optional[Dict[str, Any]] = None,
+        task_id: Optional[str] = None,
     ):
         self.message_manager = message_manager
         self.agent_manager = agent_manager
@@ -86,6 +89,7 @@ class ToolExecutionManager:
         self.actor = actor
         self.sandbox_config = sandbox_config
         self.sandbox_env_vars = sandbox_env_vars
+        self.task_id = task_id
 
     @trace_method
     async def execute_tool_async(
@@ -103,6 +107,7 @@ class ToolExecutionManager:
                 block_manager=self.block_manager,
                 passage_manager=self.passage_manager,
                 actor=self.actor,
+                task_id=self.task_id,
             )
 
             def _metrics_callback(exec_time_ms: int, exc):

--- a/letta/services/tool_executor/tool_executor_base.py
+++ b/letta/services/tool_executor/tool_executor_base.py
@@ -22,12 +22,14 @@ class ToolExecutor(ABC):
         block_manager: BlockManager,
         passage_manager: PassageManager,
         actor: User,
+        task_id: Optional[str] = None,
     ):
         self.message_manager = message_manager
         self.agent_manager = agent_manager
         self.block_manager = block_manager
         self.passage_manager = passage_manager
         self.actor = actor
+        self.task_id = task_id
 
     @abstractmethod
     async def execute(


### PR DESCRIPTION
## Summary

- Times embedding generation (`phase=embed`) and vector DB query (`phase=db_query`) separately in `list_passages`, `list_passages_async`, `list_source_passages_async`, and `list_agent_passages_async`
- Logs are gated on `task_id` being present; include `fn`, `embed_query`, `elapsed_ms`, `agent_id`, `user_id`, `task_id`, `limit`, `result_count`
- Threads `task_id` from `request.task_id` → `step()` → `ToolExecutionManager` → `ToolExecutorFactory` → `LettaCoreToolExecutor` → `list_passages_async`
- `VoiceAgent` passes `self._task_id` directly on the voice path