### PR TITLE
add `[MSG_DUP_DIAG]` debug logging to trace message duplication

### DIFF
--- a/.claude/commands/worktree-cleanup.md
+++ b/.claude/commands/worktree-cleanup.md
@@ -1,0 +1,57 @@
+Manage worktrees: list them, copy changed gitignored files from one into the main worktree, then delete it.
+
+Input: optional worktree path as $ARGUMENTS. If omitted, just list all worktrees.
+
+## Step 1 — List all worktrees
+
+Run:
+```
+git worktree list
+```
+
+If no $ARGUMENTS were provided, stop here and show the list to the user.
+
+## Step 2 — Identify the main worktree
+
+The main worktree is the first entry returned by:
+```
+git worktree list --porcelain
+```
+
+## Step 3 — Find gitignored files in the target worktree
+
+Run from the target worktree path:
+```
+git -C <target-path> ls-files --others --ignored --exclude-standard
+```
+
+Skip these noise patterns (never copy them):
+- `recordings/` — runtime audio captures
+- `logs/` — runtime log files
+- `models/` — large binary ONNX models
+- `.gitnexus/` — local code-intelligence index
+- `agora-pipeline`, `gemini-llm-server`, `basic-pipeline-test` — compiled binaries
+- `scripts/.venv/` — python virtual env
+- `.DS_Store`
+
+## Step 4 — Diff each remaining file against the main worktree
+
+For each file not matching the skip patterns:
+- If the file does not exist in the main worktree: flag it as **new**.
+- If it exists but differs: show a unified diff (`diff <target-file> <main-file>`), flag as **changed**.
+- If identical: note it as identical, no action needed.
+
+## Step 5 — Decide what to copy
+
+For each **new** or **changed** file, show the user the diff and ask whether to copy it from the target worktree into the main worktree. Copy only files the user confirms.
+
+If a file requires creating a parent directory in the main worktree, create it first.
+
+## Step 6 — Delete the worktree
+
+After all copy decisions are made, confirm with the user before deleting. Then run:
+```
+git worktree remove <target-path> --force
+```
+
+Confirm deletion succeeded by running `git worktree list` again.

--- a/letta/agents/helpers.py
+++ b/letta/agents/helpers.py
@@ -10,6 +10,7 @@ from letta.schemas.message import Message, MessageCreate
 from letta.schemas.usage import LettaUsageStatistics
 from letta.schemas.user import User
 from letta.server.rest_api.utils import create_input_messages
+from letta.debug_util import debug_log
 from letta.services.message_manager import MessageManager
 
 
@@ -112,7 +113,7 @@ async def _prepare_in_context_messages_async(
     return current_in_context_messages, new_in_context_messages
 
 
-async def _prepare_in_context_messages_no_persist_async(
+async def prepare_in_context_messages_no_persist_async(
     input_messages: List[MessageCreate],
     agent_state: AgentState,
     message_manager: MessageManager,
@@ -133,15 +134,13 @@ async def _prepare_in_context_messages_no_persist_async(
             - The new in-context messages (messages created from the new input).
     """
 
-    if agent_state.message_buffer_autoclear:
-        # If autoclear is enabled, only include the most recent system message (usually at index 0)
-        current_in_context_messages = [await message_manager.get_message_by_id_async(message_id=agent_state.message_ids[0], actor=actor)]
-    else:
-        # Otherwise, include the full list of messages by ID for context
-        current_in_context_messages = await message_manager.get_messages_by_ids_async(message_ids=agent_state.message_ids, actor=actor)
+    current_in_context_messages = await message_manager.get_messages_by_ids_async(message_ids=agent_state.message_ids or [], actor=actor)
 
     # Create a new user message from the input but dont store it yet
     new_in_context_messages = create_input_messages(input_messages=input_messages, agent_id=agent_state.id, actor=actor)
+
+    debug_log(actor.id, f"prepare_in_context_messages_no_persist_async: current_in_context_messages={current_in_context_messages}")
+    debug_log(actor.id, f"prepare_in_context_messages_no_persist_async: new_in_context_messages={new_in_context_messages}")
 
     return current_in_context_messages, new_in_context_messages
 

--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -10,7 +10,7 @@ from opentelemetry.trace import Span
 from letta.agents.base_agent import BaseAgent
 from letta.debug_util import debug_log
 from letta.agents.ephemeral_summary_agent import EphemeralSummaryAgent
-from letta.agents.helpers import _create_letta_response, _prepare_in_context_messages_no_persist_async, generate_step_id
+from letta.agents.helpers import _create_letta_response, prepare_in_context_messages_no_persist_async, generate_step_id
 from letta.constants import DEFAULT_MAX_STEPS
 from letta.errors import ContextWindowExceededError
 from letta.helpers import ToolRulesSolver
@@ -599,8 +599,15 @@ class LettaAgent(BaseAgent):
             debug_log(self.at_user_id, f"_step: cascade gate passed latency_optimisation_flow={latency_optimisation_flow}")
 
         _ctx_prep_start = get_utc_timestamp_ns() if task_id else None
+        _raw_msg_ids = agent_state.message_ids or []
+        _unique_msg_ids = set(_raw_msg_ids)
+        debug_log(
+            self.at_user_id,
+            f"_step: [MSG_DUP_DIAG] message_ids total={len(_raw_msg_ids)} unique={len(_unique_msg_ids)} "
+            f"has_dupes={len(_raw_msg_ids) != len(_unique_msg_ids)} ids={_raw_msg_ids}",
+        )
         async with AsyncTimer() as _t:
-            current_in_context_messages, new_in_context_messages = await _prepare_in_context_messages_no_persist_async(
+            current_in_context_messages, new_in_context_messages = await prepare_in_context_messages_no_persist_async(
                 input_messages, agent_state, self.message_manager, self.actor
             )
         if task_id and _ctx_prep_start:
@@ -609,7 +616,7 @@ class LettaAgent(BaseAgent):
             )
         _log_step_timing(
             "message_buffer_load",
-            _t.elapsed_ms,
+            _t.elapsed_ms or 0.0,
             agent_id=agent_state.id,
             user_id=self.at_user_id,
             msg_count=len(current_in_context_messages),
@@ -1020,6 +1027,14 @@ class LettaAgent(BaseAgent):
                     f"[TASK_LATENCY] task_id={task_id} step={i} phase=tool_exec duration_ms={ns_to_ms(get_utc_timestamp_ns() - _tool_start)}"
                 )
             self.response_messages.extend(persisted_messages)
+            _pre_extend_ids = [m.id for m in new_in_context_messages]
+            _persisted_ids = [m.id for m in persisted_messages]
+            _overlap = set(_pre_extend_ids) & set(_persisted_ids)
+            debug_log(
+                self.at_user_id,
+                f"_step: step={i} [MSG_DUP_DIAG] pre_extend_ids={_pre_extend_ids} "
+                f"persisted_ids={_persisted_ids} overlap={list(_overlap)}",
+            )
             new_in_context_messages.extend(persisted_messages)
             initial_messages = None
             _prev_tool_name = tool_call.function.name  # used by next iteration for cascade decision
@@ -1803,9 +1818,14 @@ class LettaAgent(BaseAgent):
             except Exception:
                 pass
         _t_setctx = get_utc_timestamp_ns()
-        await self.agent_manager.set_in_context_messages_async(
-            agent_id=self.agent_id, message_ids=[m.id for m in new_in_context_messages], actor=self.actor
+        _final_ids = [m.id for m in new_in_context_messages]
+        _final_unique = set(_final_ids)
+        debug_log(
+            getattr(self, "at_user_id", None),
+            f"_rebuild_context_window: [MSG_DUP_DIAG] saving message_ids total={len(_final_ids)} "
+            f"unique={len(_final_unique)} has_dupes={len(_final_ids) != len(_final_unique)} ids={_final_ids}",
         )
+        await self.agent_manager.set_in_context_messages_async(agent_id=self.agent_id, message_ids=_final_ids, actor=self.actor)
         if self._task_id:
             logger.info(
                 f"[CTXWIN_TIMING] task_id={self._task_id} agent_id={self.agent_id} "


### PR DESCRIPTION
## Summary

- Add three `[MSG_DUP_DIAG]` diagnostic logs in `_step` and `_rebuild_context_window` to trace how duplicate message IDs enter the context window
- Rename `_prepare_in_context_messages_no_persist_async` to public, remove dead `message_buffer_autoclear` branch, guard `message_ids` with `or []`
- Fix `_t.elapsed_ms or 0.0` for `_log_step_timing` float parameter
- Add `.claude/commands/worktree-cleanup.md` command