### PR TITLE
add chat_order_id to send_message logging

### DIFF
--- a/letta/debug_util.py
+++ b/letta/debug_util.py
@@ -1,6 +1,6 @@
 import uuid
 from contextvars import ContextVar
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 
 from letta.log import get_logger
 
@@ -10,6 +10,7 @@ _DEBUG_USER_ID = "125526285"
 # Holds a per-request trace ID set at send_message entry.
 # Automatically propagated to asyncio tasks via contextvars semantics.
 _debug_request_id: ContextVar[str] = ContextVar("debug_request_id", default="")
+_debug_chat_order_id: ContextVar[Optional[int]] = ContextVar("debug_chat_order_id", default=None)
 
 
 def set_debug_request_id(user_id, request_id: str) -> None:
@@ -31,6 +32,22 @@ def new_debug_request_id(user_id) -> str:
     except Exception:
         pass
     return ""
+
+
+def set_debug_chat_order_id(user_id, chat_order_id: Optional[int]) -> None:
+    """Store chat_order_id for the debug user — no-op for all others."""
+    try:
+        if str(user_id) == _DEBUG_USER_ID:
+            _debug_chat_order_id.set(chat_order_id)
+    except Exception:
+        pass
+
+
+def get_debug_chat_order_id() -> Optional[int]:
+    try:
+        return _debug_chat_order_id.get()
+    except Exception:
+        return None
 
 
 def debug_log(user_id, message: Union[str, Callable[[], str]]) -> None:

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -27,7 +27,7 @@ from letta.errors import (
 from letta.helpers.datetime_helpers import get_utc_time_int
 from letta.llm_api.bedrock_inference_profiles import COHORT_INFERENCE_PROFILES, MODEL_INFERENCE_PROFILES
 from letta.llm_api.helpers import add_inner_thoughts_to_functions, unpack_all_inner_thoughts_from_kwargs
-from letta.debug_util import _DEBUG_USER_ID, debug_log
+from letta.debug_util import _DEBUG_USER_ID, debug_log, get_debug_chat_order_id
 from letta.llm_api.llm_client_base import LLMClientBase
 from letta.local_llm.constants import INNER_THOUGHTS_KWARG, INNER_THOUGHTS_KWARG_DESCRIPTION
 from letta.log import get_logger
@@ -419,6 +419,17 @@ class AnthropicClient(LLMClientBase):
                 endpoint_type=llm_config.model_endpoint_type,
                 model=request_data.get("model"),
             )
+            _bedrock_usage = response_dict.get("usage", {})
+            debug_log(
+                _at_uid,
+                lambda _u=_bedrock_usage, _m=model_id: (
+                    f"request_async: TOKEN_USAGE(bedrock) chat_order_id={get_debug_chat_order_id()} "
+                    f"provider=anthropic_bedrock model={_m} "
+                    f"input_tokens={_u.get('input_tokens')} output_tokens={_u.get('output_tokens')} "
+                    f"cache_creation_tokens={_u.get('cache_creation_input_tokens')} "
+                    f"cache_read_tokens={_u.get('cache_read_input_tokens')}"
+                ),
+            )
             debug_log(_at_uid, lambda _r=response_dict: f"request_async: BEDROCK LLM_RESPONSE body={json.dumps(_r, default=str)}")
             return response_dict
         else:
@@ -443,6 +454,16 @@ class AnthropicClient(LLMClientBase):
             response.usage,
             endpoint_type=llm_config.model_endpoint_type,
             model=request_data.get("model"),
+        )
+        debug_log(
+            _at_uid,
+            lambda _u=response.usage, _ep=llm_config.model_endpoint_type, _m=request_data.get("model"): (
+                f"request_async: TOKEN_USAGE chat_order_id={get_debug_chat_order_id()} "
+                f"provider={_ep} model={_m} "
+                f"input_tokens={_u.input_tokens} output_tokens={_u.output_tokens} "
+                f"cache_creation_tokens={getattr(_u, 'cache_creation_input_tokens', None)} "
+                f"cache_read_tokens={getattr(_u, 'cache_read_input_tokens', None)}"
+            ),
         )
         debug_log(_at_uid, lambda _r=response: f"request_async: LLM_RESPONSE body={json.dumps(_r.model_dump(), default=str)}")
         return response.model_dump()

--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -60,6 +60,11 @@ class LettaRequest(BaseModel):
         description="Raw business ID from the order (1=AstroTalk, 10=Panditji, 12=Lumus). 0 when unavailable.",
     )
 
+    chat_order_id: Optional[int] = Field(
+        default=None,
+        description="Chat order ID from the upstream order system. Used for debug log correlation.",
+    )
+
     llm_provider: Optional[str] = Field(
         default=None,
         description="Override the LLM provider for this request. Use 'google' to route to Google AI (Gemini) regardless of the agent's configured endpoint.",

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -12,7 +12,7 @@ from sqlalchemy.exc import IntegrityError, OperationalError
 from starlette.responses import Response
 
 from letta.agents.letta_agent import LettaAgent
-from letta.debug_util import debug_log, new_debug_request_id
+from letta.debug_util import debug_log, new_debug_request_id, set_debug_chat_order_id
 from letta.constants import DEFAULT_MAX_STEPS, DEFAULT_MESSAGE_TOOL, DEFAULT_MESSAGE_TOOL_KWARG
 from letta.groups.sleeptime_multi_agent_v2 import SleeptimeMultiAgentV2
 from letta.helpers.datetime_helpers import get_utc_timestamp_ns, ns_to_ms
@@ -702,6 +702,7 @@ async def send_message(
     request_start_timestamp_ns = get_utc_timestamp_ns()
     MetricRegistry().user_message_counter.add(1, get_ctx_attributes())
     new_debug_request_id(at_user_id)
+    set_debug_chat_order_id(at_user_id, request.chat_order_id)
 
     # Tag the OTel request context with the flow flag so it propagates DOWN into
     # the agent loop and labels every nested metric (step / llm / ttft / tokens /


### PR DESCRIPTION
## Summary

- Adds `chat_order_id: Optional[int]` field to `LettaRequest` so callers can pass the upstream order ID
- Stores it in a `ContextVar` (`_debug_chat_order_id`) in `debug_util` at request entry, gated to `_DEBUG_USER_ID`
- Emits a `TOKEN_USAGE` `debug_log` line in `AnthropicClient.request_async` (both standard Anthropic and Bedrock paths) with `chat_order_id`, provider, model, input/output tokens, and cache creation/read token counts