### PR TITLE
add consultant_id routing to Bedrock inference profile

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -150,6 +150,10 @@ _HAIKU_MODEL_BY_PROVIDER: dict = {
     "anthropic_bedrock": _HAIKU_MODEL_BEDROCK_ARN,
 }
 
+# Dedicated application inference profile for consultant-routed requests.
+_CONSULTANT_BEDROCK_ARN_FOR_COST_TRACKING: str = "arn:aws:bedrock:ap-south-1:441618926843:application-inference-profile/opn9kjb11b8j"
+_CONSULTANT_ID_FOR_COST_TACKING: int = 52019
+
 # Hard cap on how long we'll wait for a Haiku LLM call before falling back to primary.
 # When Bedrock degrades (observed: p95 >24s during ap-south-1 service event Jun 2026),
 # the timeout bounds the damage to ≤8s per step instead of 24s+ per step.
@@ -223,6 +227,7 @@ class LettaAgent(BaseAgent):
         use_bedrock_experiment: bool,
         model_override: Optional[str] = None,
         llm_provider: Optional[str] = None,
+        consultant_id: int | None = None,
     ):
         """Apply dynamic provider switching based on experiment flags."""
         # Runtime model override: swap the model name before any endpoint-type remapping
@@ -235,6 +240,11 @@ class LettaAgent(BaseAgent):
         # Also auto-detect Gemini models by name so callers don't need to set llm_provider explicitly.
         if llm_provider == "google" or (agent_state.llm_config.model or "").startswith("gemini"):
             agent_state.llm_config.model_endpoint_type = "google_ai"
+            return
+
+        if consultant_id == _CONSULTANT_ID_FOR_COST_TACKING:
+            agent_state.llm_config.model_endpoint_type = "anthropic_bedrock"
+            agent_state.llm_config.model = _CONSULTANT_BEDROCK_ARN_FOR_COST_TRACKING
             return
 
         original_endpoint_type = agent_state.llm_config.model_endpoint_type
@@ -273,6 +283,7 @@ class LettaAgent(BaseAgent):
         task_id: Optional[str] = None,
         latency_optimisation_flow: bool = False,
         llm_provider: Optional[str] = None,
+        consultant_id: int | None = None,
     ) -> LettaResponse:
         _t_agent_load_start = get_utc_timestamp_ns() if task_id else None
         agent_state = await self.agent_manager.get_agent_by_id_async(
@@ -297,6 +308,7 @@ class LettaAgent(BaseAgent):
             task_id=task_id,
             latency_optimisation_flow=latency_optimisation_flow,
             llm_provider=llm_provider,
+            consultant_id=consultant_id,
         )
         return _create_letta_response(
             new_in_context_messages=new_in_context_messages,
@@ -572,6 +584,7 @@ class LettaAgent(BaseAgent):
         task_id: Optional[str] = None,
         latency_optimisation_flow: bool = False,
         llm_provider: Optional[str] = None,
+        consultant_id: int | None = None,
     ) -> Tuple[List[Message], List[Message], Optional[LettaStopReason], LettaUsageStatistics]:
         """
         Carries out an invocation of the agent loop. In each step, the agent
@@ -582,7 +595,12 @@ class LettaAgent(BaseAgent):
         """
         # Handle provider switching based on experiment flags
         self._apply_provider_switching(
-            agent_state, use_vertex_experiment, use_bedrock_experiment, model_override=model_override, llm_provider=llm_provider
+            agent_state,
+            use_vertex_experiment,
+            use_bedrock_experiment,
+            model_override=model_override,
+            llm_provider=llm_provider,
+            consultant_id=consultant_id,
         )
 
         # Stash task_id on the instance so agent-internal helpers (_rebuild_memory_async,

--- a/letta/schemas/letta_request.py
+++ b/letta/schemas/letta_request.py
@@ -65,6 +65,11 @@ class LettaRequest(BaseModel):
         description="Chat order ID from the upstream order system. Used for debug log correlation.",
     )
 
+    consultant_id: int | None = Field(
+        default=None,
+        description="Consultant identifier from the upstream order. When provided alongside llm_provider='bedrock', pins the call to the dedicated consultant Bedrock inference profile.",
+    )
+
     llm_provider: Optional[str] = Field(
         default=None,
         description="Override the LLM provider for this request. Use 'google' to route to Google AI (Gemini) regardless of the agent's configured endpoint.",

--- a/letta/server/rest_api/routers/v1/agents.py
+++ b/letta/server/rest_api/routers/v1/agents.py
@@ -796,6 +796,7 @@ async def send_message(
             task_id=request.task_id,
             latency_optimisation_flow=request.latencyOptimisationFlow,
             llm_provider=request.llm_provider,
+            consultant_id=request.consultant_id,
         )
         return result
     except Exception as e:


### PR DESCRIPTION
## Summary

- Adds `consultant_id` (int) field to `LettaRequest` so the Go AI chat service can pass it in the send-message payload
- Handles `llm_provider='bedrock'` in `_apply_provider_switching` (previously only `'google'` was handled) — switches endpoint type to `anthropic_bedrock`
- When `consultant_id` matches the designated cost-tracking consultant ID, pins the model to the dedicated application inference profile ARN (`arn:aws:bedrock:ap-south-1:441618926843:application-inference-profile/opn9kjb11b8j`), which is used verbatim by `AnthropicClient` bypassing cohort/env-var resolution
- Threads `consultant_id` through `step()` → `_step()` → `_apply_provider_switching()`