### PR TITLE
expose cache token counts in LettaUsageStatistics response

### DIFF
--- a/letta/agents/letta_agent.py
+++ b/letta/agents/letta_agent.py
@@ -992,11 +992,12 @@ class LettaAgent(BaseAgent):
                         lambda _i=i, _r=response: f"_step: step={_i} PRIMARY_RETRY complete tool={_r.choices[0].message.tool_calls[0].function.name if _r.choices[0].message.tool_calls else 'text'}",
                     )
 
-            # TODO: add run_id
             usage.step_count += 1
             usage.completion_tokens += response.usage.completion_tokens
             usage.prompt_tokens += response.usage.prompt_tokens
             usage.total_tokens += response.usage.total_tokens
+            usage.cache_read_tokens += response.usage.cache_read_input_tokens
+            usage.cache_creation_tokens += response.usage.cache_creation_input_tokens
             MetricRegistry().message_output_tokens.record(
                 response.usage.completion_tokens, dict(get_ctx_attributes(), **{"model.name": agent_state.llm_config.model})
             )
@@ -1271,6 +1272,20 @@ class LettaAgent(BaseAgent):
             if request_start_timestamp_ns:
                 _request_ms = ns_to_ms(get_utc_timestamp_ns() - request_start_timestamp_ns)
                 MetricRegistry().haiku_cascade_request_ms_histogram.record(_request_ms, _summary_attrs)
+
+        if self._consultant_id in TASK_LATENCY_CONSULTANT_IDS:
+            logger.warning(
+                "[STEP_USAGE] consultant_id=%s steps=%d prompt_tokens=%d completion_tokens=%d "
+                "total_tokens=%d cache_read_tokens=%d cache_creation_tokens=%d stop_reason=%s",
+                self._consultant_id,
+                usage.step_count,
+                usage.prompt_tokens,
+                usage.completion_tokens,
+                usage.total_tokens,
+                usage.cache_read_tokens,
+                usage.cache_creation_tokens,
+                stop_reason.stop_reason if stop_reason else None,
+            )
 
         return current_in_context_messages, new_in_context_messages, usage, stop_reason
 

--- a/letta/llm_api/anthropic_client.py
+++ b/letta/llm_api/anthropic_client.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 import logging
 import re
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import anthropic
 from anthropic import AsyncStream
@@ -1316,13 +1316,11 @@ class AnthropicClient(LLMClientBase):
 
         return super().handle_llm_error(e)
 
-    # TODO: Input messages doesn't get used here
-    # TODO: Clean up this interface
     @trace_method
     def convert_response_to_chat_completion(
         self,
-        response_data: dict,
-        input_messages: List[PydanticMessage],
+        response_data: dict[str, Any],
+        input_messages: list[PydanticMessage],
         llm_config: LLMConfig,
     ) -> ChatCompletionResponse:
         """
@@ -1362,6 +1360,8 @@ class AnthropicClient(LLMClientBase):
         response = AnthropicMessage(**response_data)
         prompt_tokens = response.usage.input_tokens
         completion_tokens = response.usage.output_tokens
+        cache_read_input_tokens = response.usage.cache_read_input_tokens or 0
+        cache_creation_input_tokens = response.usage.cache_creation_input_tokens or 0
         finish_reason = remap_finish_reason(str(response.stop_reason))
 
         content = None
@@ -1494,6 +1494,8 @@ class AnthropicClient(LLMClientBase):
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 total_tokens=prompt_tokens + completion_tokens,
+                cache_read_input_tokens=cache_read_input_tokens,
+                cache_creation_input_tokens=cache_creation_input_tokens,
             ),
         )
         if llm_config.put_inner_thoughts_in_kwargs:

--- a/letta/schemas/openai/chat_completion_response.py
+++ b/letta/schemas/openai/chat_completion_response.py
@@ -105,6 +105,9 @@ class UsageStatistics(BaseModel):
     prompt_tokens_details: Optional[UsageStatisticsPromptTokenDetails] = None
     completion_tokens_details: Optional[UsageStatisticsCompletionTokenDetails] = None
 
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
+
     def __add__(self, other: "UsageStatistics") -> "UsageStatistics":
 
         if self.prompt_tokens_details is None and other.prompt_tokens_details is None:
@@ -131,6 +134,8 @@ class UsageStatistics(BaseModel):
             total_tokens=self.total_tokens + other.total_tokens,
             prompt_tokens_details=total_prompt_tokens_details,
             completion_tokens_details=total_completion_tokens_details,
+            cache_read_input_tokens=self.cache_read_input_tokens + other.cache_read_input_tokens,
+            cache_creation_input_tokens=self.cache_creation_input_tokens + other.cache_creation_input_tokens,
         )
 
 

--- a/letta/schemas/usage.py
+++ b/letta/schemas/usage.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -21,6 +21,7 @@ class LettaUsageStatistics(BaseModel):
     prompt_tokens: int = Field(0, description="The number of tokens in the prompt.")
     total_tokens: int = Field(0, description="The total number of tokens processed by the agent.")
     step_count: int = Field(0, description="The number of steps taken by the agent.")
-    # TODO: Optional for now. This field makes everyone's lives easier
-    steps_messages: Optional[List[List[Message]]] = Field(None, description="The messages generated per step")
-    run_ids: Optional[List[str]] = Field(None, description="The background task run IDs associated with the agent interaction")
+    cache_read_tokens: int = Field(0, description="Prompt tokens served from Anthropic prompt cache (cache_read_input_tokens).")
+    cache_creation_tokens: int = Field(0, description="Prompt tokens written to Anthropic prompt cache (cache_creation_input_tokens).")
+    steps_messages: Optional[list[list[Message]]] = Field(None, description="The messages generated per step")
+    run_ids: Optional[list[str]] = Field(None, description="The background task run IDs associated with the agent interaction")


### PR DESCRIPTION
## Summary

- Adds `cache_read_tokens` and `cache_creation_tokens` to `LettaUsageStatistics` so callers get the full Anthropic prompt-cache token breakdown in every `/messages` response
- Adds `cache_read_input_tokens` / `cache_creation_input_tokens` to the intermediate `UsageStatistics` type with proper `__add__` accumulation across steps
- Extracts both fields from `response.usage` in `AnthropicClient.convert_response_to_chat_completion` — covers direct Anthropic, Vertex, and Bedrock (primary + timeout fallback); non-Anthropic providers default to `0`
- Accumulates per-step cache tokens into `LettaUsageStatistics` in `LettaAgent._step()`
- Adds a `[STEP_USAGE]` log line before `_step()` returns for consultant IDs in `TASK_LATENCY_CONSULTANT_IDS` with the full token breakdown including cache fields